### PR TITLE
fix(notifications): Phase G+H — title-change IPC bypass + sender/typing-rearm/taskbar (Win11/Linux)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -116,6 +116,13 @@ pub(crate) enum NotifState {
         prev_fired_at_secs: u64,
         /// When count first dropped to zero.
         zero_since_secs: u64,
+        /// Whether this zero was triggered by a typing-indicator title
+        /// (title lacks a `(N)` prefix and the `| Messenger` suffix).
+        ///
+        /// When `true`, a count return within `TYPING_REARM_SECS` may
+        /// re-fire so the user is notified of the message that followed
+        /// the typing indicator.
+        zero_from_typing: bool,
     },
 }
 
@@ -135,6 +142,20 @@ const ZERO_SUSTAIN_SECS: u64 = 7;
 /// are never delayed.  `ZeroPending` sig-changed also respects this floor
 /// because the previous fire timestamp is carried over into that state.
 const MIN_SIG_CHANGE_NOTIFY_SECS: u64 = 3;
+
+/// Minimum seconds after the previous notification before a typing-indicator
+/// zero-bounce may re-arm and fire a new banner.
+///
+/// Messenger momentarily sets the title to a locale-specific typing string
+/// (e.g. "Alice is typing…", "Jouda píše!") — count=0 — then restores the
+/// `(N) SENDER | Messenger` title when the message arrives.  Without re-arming
+/// the user would miss the new-message notification for the same count because
+/// `zero-bounce-oscillation-suppressed` blocks it.
+///
+/// The floor prevents rapid oscillation spam: if the typing indicator fires and
+/// count bounces back before `TYPING_REARM_SECS` have elapsed since the last
+/// notification, no new banner is shown.
+const TYPING_REARM_SECS: u64 = 5;
 
 /// Returns the current Unix time in seconds (best-effort; 0 on error).
 fn now_secs() -> u64 {
@@ -185,6 +206,7 @@ fn decide_notification(
     activity_sig: &str,
     is_focused: bool,
     notifications_enabled: bool,
+    is_typing_indicator: bool,
     now: u64,
 ) -> NotificationDecision {
     match state.clone() {
@@ -228,6 +250,7 @@ fn decide_notification(
                     prev_sig,
                     prev_fired_at_secs: fired_at_secs,
                     zero_since_secs: now,
+                    zero_from_typing: is_typing_indicator,
                 };
                 NotificationDecision {
                     should_fire: false,
@@ -282,6 +305,7 @@ fn decide_notification(
             prev_sig,
             prev_fired_at_secs,
             zero_since_secs,
+            zero_from_typing,
         } => {
             if count == 0 {
                 let zero_elapsed = now.saturating_sub(zero_since_secs);
@@ -314,15 +338,21 @@ fn decide_notification(
                 // Same floor as the Notified arm: sig-only fires are rate-limited.
                 let sig_under_floor =
                     sig_changed && !count_increased && elapsed < MIN_SIG_CHANGE_NOTIFY_SECS;
+                // Re-arm: the previous zero came from a typing indicator and enough
+                // time has elapsed since the last notification, so the returning
+                // count represents a message that was sent after typing — fire.
+                let typing_rearm = zero_from_typing && elapsed >= TYPING_REARM_SECS;
                 let should_fire = notifications_enabled
                     && !is_focused
-                    && (count_increased || (sig_changed && !sig_under_floor));
+                    && (count_increased || (sig_changed && !sig_under_floor) || typing_rearm);
                 let reason = if count_increased {
                     "zero-bounce-count-increased"
                 } else if sig_changed && sig_under_floor {
                     "zero-bounce-sig-floor-suppressed"
                 } else if sig_changed {
                     "zero-bounce-sig-changed"
+                } else if typing_rearm {
+                    "typing-indicator-rearm"
                 } else {
                     "zero-bounce-oscillation-suppressed"
                 };
@@ -417,11 +447,47 @@ pub fn send_notification(
 /// `count=0` first enters `ZeroPending` and clears badge/tray only after the zero
 /// state is sustained.  This avoids re-firing every few seconds on title
 /// oscillation while still clearing the badge after an actual read-all.
+///
+/// Called from JS via IPC — `is_typing_indicator` is always `false` here because
+/// JS has no reliable way to detect the typing indicator title format.  Use
+/// [`update_unread_count_from_title`] for the Rust-side title-change handler
+/// which has full title context.
 #[tauri::command]
 pub fn update_unread_count(
     count: u32,
     sender: String,
     activity_sig: String,
+    app: AppHandle,
+) -> Result<(), String> {
+    update_unread_count_core(count, sender, activity_sig, false, app)
+}
+
+/// Variant of [`update_unread_count`] called directly from the Rust-side
+/// `on_document_title_changed` handler.
+///
+/// Unlike the IPC command, this call-site knows:
+/// - `sender` — parsed from `(N) SENDER | Messenger` title format.
+/// - `is_typing_indicator` — whether the title was a locale-specific typing
+///   indicator (e.g. "Alice is typing…", "Jouda píše!") rather than a
+///   real unread-count title.
+///
+/// `activity_sig` is always empty here because there is no DOM access from Rust.
+pub(crate) fn update_unread_count_from_title(
+    count: u32,
+    sender: String,
+    is_typing_indicator: bool,
+    app: AppHandle,
+) -> Result<(), String> {
+    update_unread_count_core(count, sender, String::new(), is_typing_indicator, app)
+}
+
+/// Shared implementation for [`update_unread_count`] and
+/// [`update_unread_count_from_title`].
+fn update_unread_count_core(
+    count: u32,
+    sender: String,
+    activity_sig: String,
+    is_typing_indicator: bool,
     app: AppHandle,
 ) -> Result<(), String> {
     // ------------------------------------------------------------------
@@ -463,13 +529,16 @@ pub fn update_unread_count(
             &activity_sig,
             is_focused,
             settings.notifications_enabled,
+            is_typing_indicator,
             now,
         );
         (decision, state.clone())
     };
 
     log::info!(
-        "[MessengerX][Notification][DECISION] count={} old_count={} focused={} enabled={} reason={} fire={} clear_badge={} prev_count={} count_increased={} sig_changed={} elapsed={:?} activity_sig={:?} state_after={:?}",
+        "[MessengerX][Notification][DECISION] count={} old_count={} focused={} enabled={} \
+         reason={} fire={} clear_badge={} prev_count={} count_increased={} sig_changed={} \
+         elapsed={:?} typing={} activity_sig={:?} state_after={:?}",
         count,
         old_count,
         is_focused,
@@ -481,6 +550,7 @@ pub fn update_unread_count(
         decision.count_increased,
         decision.sig_changed,
         decision.elapsed_since_fire,
+        is_typing_indicator,
         activity_sig,
         state_after,
     );
@@ -518,12 +588,14 @@ pub fn update_unread_count(
         };
         log::info!(
             "[MessengerX][Notification] firing notification: count {} → {}; \
-             reason={} count_increased={} sig_changed={}; sender={:?} activity_sig={:?} silent={}",
+             reason={} count_increased={} sig_changed={} typing={}; \
+             sender={:?} activity_sig={:?} silent={}",
             decision.previous_count,
             count,
             decision.reason,
             decision.count_increased,
             decision.sig_changed,
+            is_typing_indicator,
             sender,
             activity_sig,
             effective_silent,
@@ -565,6 +637,26 @@ pub fn update_unread_count(
             };
             if let Err(e) = webview.set_badge_label(label) {
                 log::warn!("[MessengerX][Badge] Failed to set dock badge: {e}");
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // 3b. Taskbar / dock attention request (Win11 + Linux only).
+    //     On macOS the Dock badge (section 3) already draws sufficient
+    //     attention; on Win11/Linux we flash the taskbar button /
+    //     set the window urgency hint so the user notices the new message
+    //     even when the app is in the background or minimised.
+    //     The platform clears the attention signal automatically once the
+    //     window is focused — no explicit teardown required.
+    // ------------------------------------------------------------------
+    #[cfg(not(target_os = "macos"))]
+    if decision.should_fire {
+        if let Some(ref w) = main_window {
+            if let Err(e) =
+                w.request_user_attention(Some(tauri::UserAttentionType::Informational))
+            {
+                log::warn!("[MessengerX][Attention] request_user_attention failed: {e}");
             }
         }
     }
@@ -870,7 +962,7 @@ mod tests {
     #[test]
     fn test_notif_state_idle_positive_fires() {
         let mut state = NotifState::Idle;
-        let decision = decide_notification(&mut state, 1, "", false, true, 100);
+        let decision = decide_notification(&mut state, 1, "", false, true, false, 100);
         assert!(decision.should_fire);
         assert_eq!(decision.reason, "idle-count-positive");
         assert_eq!(
@@ -891,12 +983,12 @@ mod tests {
             fired_at_secs: 100,
         };
 
-        let zero = decide_notification(&mut state, 0, "", false, true, 103);
+        let zero = decide_notification(&mut state, 0, "", false, true, false, 103);
         assert!(!zero.should_fire);
         assert!(!zero.clear_badge);
         assert_eq!(zero.reason, "zero-pending-start");
 
-        let bounce = decide_notification(&mut state, 1, "", false, true, 106);
+        let bounce = decide_notification(&mut state, 1, "", false, true, false, 106);
         assert!(!bounce.should_fire);
         assert_eq!(bounce.reason, "zero-bounce-oscillation-suppressed");
         assert_eq!(
@@ -917,8 +1009,8 @@ mod tests {
             fired_at_secs: 100,
         };
 
-        let _ = decide_notification(&mut state, 0, "", false, true, 103);
-        let sustained = decide_notification(&mut state, 0, "", false, true, 111);
+        let _ = decide_notification(&mut state, 0, "", false, true, false, 103);
+        let sustained = decide_notification(&mut state, 0, "", false, true, false, 111);
         assert!(!sustained.should_fire);
         assert!(sustained.clear_badge);
         assert_eq!(sustained.reason, "zero-sustained-read-all");
@@ -933,9 +1025,9 @@ mod tests {
             fired_at_secs: 100,
         };
 
-        let _ = decide_notification(&mut state, 0, "", false, true, 103);
-        let _ = decide_notification(&mut state, 0, "", false, true, 111);
-        let next = decide_notification(&mut state, 1, "", false, true, 112);
+        let _ = decide_notification(&mut state, 0, "", false, true, false, 103);
+        let _ = decide_notification(&mut state, 0, "", false, true, false, 111);
+        let next = decide_notification(&mut state, 1, "", false, true, false, 112);
         assert!(next.should_fire);
         assert_eq!(next.reason, "idle-count-positive");
     }
@@ -947,9 +1039,10 @@ mod tests {
             prev_sig: "1:0:Alice".to_string(),
             prev_fired_at_secs: 100,
             zero_since_secs: 103,
+            zero_from_typing: false,
         };
 
-        let decision = decide_notification(&mut state, 1, "1:1:Alice", false, true, 104);
+        let decision = decide_notification(&mut state, 1, "1:1:Alice", false, true, false, 104);
         assert!(decision.should_fire);
         assert!(decision.sig_changed);
         assert_eq!(decision.reason, "zero-bounce-sig-changed");
@@ -981,7 +1074,7 @@ mod tests {
         };
         // elapsed = 100+MIN_SIG_CHANGE_NOTIFY_SECS — exactly at the boundary → allow
         let now = 100 + MIN_SIG_CHANGE_NOTIFY_SECS;
-        let decision = decide_notification(&mut state, 1, "1:1:Alice", false, true, now);
+        let decision = decide_notification(&mut state, 1, "1:1:Alice", false, true, false, now);
         assert!(decision.should_fire, "sig_changed after floor should fire");
         assert_eq!(decision.reason, "sig-changed");
     }
@@ -996,7 +1089,7 @@ mod tests {
         };
         // elapsed = MIN_SIG_CHANGE_NOTIFY_SECS - 1 → below floor → suppress
         let now = 100 + MIN_SIG_CHANGE_NOTIFY_SECS - 1;
-        let decision = decide_notification(&mut state, 1, "1:1:Alice", false, true, now);
+        let decision = decide_notification(&mut state, 1, "1:1:Alice", false, true, false, now);
         assert!(
             !decision.should_fire,
             "sig_changed under floor must be suppressed"
@@ -1013,7 +1106,7 @@ mod tests {
             fired_at_secs: 100,
         };
         // elapsed = 0 — well under the floor, but count increased → must fire
-        let decision = decide_notification(&mut state, 2, "2:0:Alice", false, true, 100);
+        let decision = decide_notification(&mut state, 2, "2:0:Alice", false, true, false, 100);
         assert!(
             decision.should_fire,
             "count_increased must bypass sig floor"
@@ -1042,7 +1135,7 @@ mod tests {
     fn test_count_increase_fires_with_empty_sig() {
         let mut state = NotifState::Idle;
         // count > 0, empty sig — should still fire on count-increase from Idle.
-        let decision = decide_notification(&mut state, 3, "", false, true, 200);
+        let decision = decide_notification(&mut state, 3, "", false, true, false, 200);
         assert!(
             decision.should_fire,
             "count-increase from Idle must fire even with empty activity_sig"
@@ -1060,7 +1153,7 @@ mod tests {
             fired_at_secs: 100,
         };
         // Same count, empty sig — must not fire.
-        let decision = decide_notification(&mut state, 1, "", false, true, 200);
+        let decision = decide_notification(&mut state, 1, "", false, true, false, 200);
         assert!(
             !decision.should_fire,
             "empty activity_sig must not trigger sig_changed notification"
@@ -1069,6 +1162,104 @@ mod tests {
             !decision.sig_changed,
             "sig_changed must be false for empty sig"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Typing-indicator re-arm tests (TYPING_REARM_SECS)
+    // -----------------------------------------------------------------------
+
+    /// After a typing-indicator zero, count returning once TYPING_REARM_SECS
+    /// have elapsed since the previous notification should re-fire.
+    #[test]
+    fn test_typing_indicator_rearm_fires_after_cooldown() {
+        // Simulate: notification fired at T=100, typing indicator at T=106,
+        // message arrives at T=108 (elapsed from fired_at = 8 ≥ TYPING_REARM_SECS=5).
+        let mut state = NotifState::Notified {
+            count: 1,
+            sig: String::new(),
+            fired_at_secs: 100,
+        };
+
+        // Typing indicator fires — count drops to 0, is_typing_indicator=true.
+        let zero = decide_notification(&mut state, 0, "", false, true, true, 106);
+        assert!(!zero.should_fire);
+        assert_eq!(zero.reason, "zero-pending-start");
+        // Confirm zero_from_typing was stored.
+        assert_eq!(
+            state,
+            NotifState::ZeroPending {
+                prev_count: 1,
+                prev_sig: String::new(),
+                prev_fired_at_secs: 100,
+                zero_since_secs: 106,
+                zero_from_typing: true,
+            }
+        );
+
+        // Message arrives — count returns, elapsed = 108-100 = 8 ≥ 5 → re-arm.
+        let rearm = decide_notification(&mut state, 1, "", false, true, false, 108);
+        assert!(rearm.should_fire, "typing rearm must fire after cooldown");
+        assert_eq!(rearm.reason, "typing-indicator-rearm");
+    }
+
+    /// Typing-indicator zero followed by a quick count return (elapsed <
+    /// TYPING_REARM_SECS) must NOT re-fire — rapid oscillation guard.
+    #[test]
+    fn test_typing_indicator_rearm_suppressed_too_soon() {
+        let mut state = NotifState::Notified {
+            count: 1,
+            sig: String::new(),
+            fired_at_secs: 100,
+        };
+
+        // Typing indicator at T=101 (elapsed so far: 1s).
+        let _ = decide_notification(&mut state, 0, "", false, true, true, 101);
+
+        // Count returns at T=103 — elapsed = 3 < TYPING_REARM_SECS=5 → no fire.
+        let d = decide_notification(&mut state, 1, "", false, true, false, 103);
+        assert!(
+            !d.should_fire,
+            "typing rearm must be suppressed before cooldown expires"
+        );
+        assert_eq!(d.reason, "zero-bounce-oscillation-suppressed");
+    }
+
+    /// Regular oscillation (non-typing zero) must NOT be affected by the
+    /// typing-indicator re-arm path even when enough time has elapsed.
+    #[test]
+    fn test_non_typing_zero_not_rearmed() {
+        let mut state = NotifState::Notified {
+            count: 1,
+            sig: String::new(),
+            fired_at_secs: 100,
+        };
+
+        // Regular zero (not typing indicator) at T=103.
+        let _ = decide_notification(&mut state, 0, "", false, true, false, 103);
+
+        // Count returns at T=110 — elapsed=10 ≥ TYPING_REARM_SECS, but
+        // zero_from_typing=false so typing_rearm must NOT trigger.
+        let d = decide_notification(&mut state, 1, "", false, true, false, 110);
+        assert!(
+            !d.should_fire,
+            "non-typing zero bounce must not re-arm even after cooldown"
+        );
+        assert_eq!(d.reason, "zero-bounce-oscillation-suppressed");
+    }
+
+    /// Verify TYPING_REARM_SECS constant is within a sensible range.
+    #[test]
+    fn test_typing_rearm_constant_is_reasonable() {
+        const _: () = {
+            assert!(
+                TYPING_REARM_SECS >= 3,
+                "rearm floor must exceed oscillation interval (~3s)"
+            );
+            assert!(
+                TYPING_REARM_SECS <= 15,
+                "rearm floor must be short enough to catch real replies"
+            );
+        };
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -104,6 +104,19 @@ pub(crate) enum NotifState {
         sig: String,
         /// Unix timestamp (seconds) when the notification fired.
         fired_at_secs: u64,
+        /// Whether the typing-indicator re-arm has already fired once for this
+        /// `Notified` entry.
+        ///
+        /// The re-arm path (`typing-indicator-rearm`) is allowed to fire at
+        /// most **once** per `Notified` entry.  Without this guard, the cycle
+        /// `typing(count=0) → message(count=1)` repeats indefinitely: each
+        /// re-arm creates a fresh `Notified{fired_at=now}`, which then enters
+        /// `ZeroPending{prev_fired_at=now}`, and after `TYPING_REARM_SECS`
+        /// have elapsed the re-arm fires again — an infinite notification spam.
+        ///
+        /// Reset to `false` when a genuine `count_increased` or `sig_changed`
+        /// notification fires, indicating a truly new message (not a re-arm).
+        typing_rearm_exhausted: bool,
     },
     /// Count just dropped to 0 after a notification.  We wait for zero to be
     /// sustained before treating it as a real read-all reset.
@@ -123,6 +136,13 @@ pub(crate) enum NotifState {
         /// re-fire so the user is notified of the message that followed
         /// the typing indicator.
         zero_from_typing: bool,
+        /// Carried forward from `Notified::typing_rearm_exhausted`.
+        ///
+        /// When `true`, the typing-indicator re-arm is blocked even if
+        /// `zero_from_typing` is `true` and enough time has elapsed.  This
+        /// prevents the infinite-spam loop described in
+        /// `Notified::typing_rearm_exhausted`.
+        prev_typing_rearm_exhausted: bool,
     },
 }
 
@@ -218,6 +238,7 @@ fn decide_notification(
                     count,
                     sig: activity_sig.to_owned(),
                     fired_at_secs: now,
+                    typing_rearm_exhausted: false,
                 };
                 NotificationDecision {
                     should_fire: true,
@@ -243,6 +264,7 @@ fn decide_notification(
             count: prev_count,
             sig: prev_sig,
             fired_at_secs,
+            typing_rearm_exhausted,
         } => {
             if count == 0 {
                 *state = NotifState::ZeroPending {
@@ -251,6 +273,7 @@ fn decide_notification(
                     prev_fired_at_secs: fired_at_secs,
                     zero_since_secs: now,
                     zero_from_typing: is_typing_indicator,
+                    prev_typing_rearm_exhausted: typing_rearm_exhausted,
                 };
                 NotificationDecision {
                     should_fire: false,
@@ -287,6 +310,7 @@ fn decide_notification(
                         count,
                         sig: activity_sig.to_owned(),
                         fired_at_secs: now,
+                        typing_rearm_exhausted: false,
                     };
                 }
                 NotificationDecision {
@@ -306,6 +330,7 @@ fn decide_notification(
             prev_fired_at_secs,
             zero_since_secs,
             zero_from_typing,
+            prev_typing_rearm_exhausted,
         } => {
             if count == 0 {
                 let zero_elapsed = now.saturating_sub(zero_since_secs);
@@ -338,10 +363,14 @@ fn decide_notification(
                 // Same floor as the Notified arm: sig-only fires are rate-limited.
                 let sig_under_floor =
                     sig_changed && !count_increased && elapsed < MIN_SIG_CHANGE_NOTIFY_SECS;
-                // Re-arm: the previous zero came from a typing indicator and enough
-                // time has elapsed since the last notification, so the returning
-                // count represents a message that was sent after typing — fire.
-                let typing_rearm = zero_from_typing && elapsed >= TYPING_REARM_SECS;
+                // Re-arm: the previous zero came from a typing indicator, enough
+                // time has elapsed, and the rearm has NOT already fired once for
+                // this Notified entry.  The `prev_typing_rearm_exhausted` guard
+                // breaks the infinite loop: rearm → Notified{exhausted=true} →
+                // ZeroPending{prev_exhausted=true} → rearm blocked.
+                let typing_rearm = zero_from_typing
+                    && elapsed >= TYPING_REARM_SECS
+                    && !prev_typing_rearm_exhausted;
                 let should_fire = notifications_enabled
                     && !is_focused
                     && (count_increased || (sig_changed && !sig_under_floor) || typing_rearm);
@@ -356,10 +385,20 @@ fn decide_notification(
                 } else {
                     "zero-bounce-oscillation-suppressed"
                 };
+                // Compute whether the new Notified entry should block future rearms:
+                //   - genuine fire (count/sig): reset to false — new message, rearm allowed again
+                //   - typing_rearm fire:        set to true  — consumed the one allowed rearm
+                //   - no fire (suppressed):     carry forward prev so it survives oscillation
+                let new_typing_rearm_exhausted = if should_fire {
+                    typing_rearm // true only when the rearm path fired
+                } else {
+                    prev_typing_rearm_exhausted
+                };
                 *state = NotifState::Notified {
                     count,
                     sig: activity_sig.to_owned(),
                     fired_at_secs: if should_fire { now } else { prev_fired_at_secs },
+                    typing_rearm_exhausted: new_typing_rearm_exhausted,
                 };
                 NotificationDecision {
                     should_fire,
@@ -653,8 +692,7 @@ fn update_unread_count_core(
     #[cfg(not(target_os = "macos"))]
     if decision.should_fire {
         if let Some(ref w) = main_window {
-            if let Err(e) =
-                w.request_user_attention(Some(tauri::UserAttentionType::Informational))
+            if let Err(e) = w.request_user_attention(Some(tauri::UserAttentionType::Informational))
             {
                 log::warn!("[MessengerX][Attention] request_user_attention failed: {e}");
             }
@@ -971,6 +1009,7 @@ mod tests {
                 count: 1,
                 sig: String::new(),
                 fired_at_secs: 100,
+                typing_rearm_exhausted: false,
             }
         );
     }
@@ -981,6 +1020,7 @@ mod tests {
             count: 1,
             sig: String::new(),
             fired_at_secs: 100,
+            typing_rearm_exhausted: false,
         };
 
         let zero = decide_notification(&mut state, 0, "", false, true, false, 103);
@@ -997,6 +1037,7 @@ mod tests {
                 count: 1,
                 sig: String::new(),
                 fired_at_secs: 100,
+                typing_rearm_exhausted: false,
             }
         );
     }
@@ -1007,6 +1048,7 @@ mod tests {
             count: 1,
             sig: String::new(),
             fired_at_secs: 100,
+            typing_rearm_exhausted: false,
         };
 
         let _ = decide_notification(&mut state, 0, "", false, true, false, 103);
@@ -1023,6 +1065,7 @@ mod tests {
             count: 1,
             sig: String::new(),
             fired_at_secs: 100,
+            typing_rearm_exhausted: false,
         };
 
         let _ = decide_notification(&mut state, 0, "", false, true, false, 103);
@@ -1040,6 +1083,7 @@ mod tests {
             prev_fired_at_secs: 100,
             zero_since_secs: 103,
             zero_from_typing: false,
+            prev_typing_rearm_exhausted: false,
         };
 
         let decision = decide_notification(&mut state, 1, "1:1:Alice", false, true, false, 104);
@@ -1071,6 +1115,7 @@ mod tests {
             count: 1,
             sig: "1:0:Alice".to_string(),
             fired_at_secs: 100,
+            typing_rearm_exhausted: false,
         };
         // elapsed = 100+MIN_SIG_CHANGE_NOTIFY_SECS — exactly at the boundary → allow
         let now = 100 + MIN_SIG_CHANGE_NOTIFY_SECS;
@@ -1086,6 +1131,7 @@ mod tests {
             count: 1,
             sig: "1:0:Alice".to_string(),
             fired_at_secs: 100,
+            typing_rearm_exhausted: false,
         };
         // elapsed = MIN_SIG_CHANGE_NOTIFY_SECS - 1 → below floor → suppress
         let now = 100 + MIN_SIG_CHANGE_NOTIFY_SECS - 1;
@@ -1104,6 +1150,7 @@ mod tests {
             count: 1,
             sig: "1:0:Alice".to_string(),
             fired_at_secs: 100,
+            typing_rearm_exhausted: false,
         };
         // elapsed = 0 — well under the floor, but count increased → must fire
         let decision = decide_notification(&mut state, 2, "2:0:Alice", false, true, false, 100);
@@ -1151,6 +1198,7 @@ mod tests {
             count: 1,
             sig: "1:0:Alice".to_string(),
             fired_at_secs: 100,
+            typing_rearm_exhausted: false,
         };
         // Same count, empty sig — must not fire.
         let decision = decide_notification(&mut state, 1, "", false, true, false, 200);
@@ -1178,6 +1226,7 @@ mod tests {
             count: 1,
             sig: String::new(),
             fired_at_secs: 100,
+            typing_rearm_exhausted: false,
         };
 
         // Typing indicator fires — count drops to 0, is_typing_indicator=true.
@@ -1193,6 +1242,7 @@ mod tests {
                 prev_fired_at_secs: 100,
                 zero_since_secs: 106,
                 zero_from_typing: true,
+                prev_typing_rearm_exhausted: false,
             }
         );
 
@@ -1210,6 +1260,7 @@ mod tests {
             count: 1,
             sig: String::new(),
             fired_at_secs: 100,
+            typing_rearm_exhausted: false,
         };
 
         // Typing indicator at T=101 (elapsed so far: 1s).
@@ -1232,6 +1283,7 @@ mod tests {
             count: 1,
             sig: String::new(),
             fired_at_secs: 100,
+            typing_rearm_exhausted: false,
         };
 
         // Regular zero (not typing indicator) at T=103.
@@ -1245,6 +1297,76 @@ mod tests {
             "non-typing zero bounce must not re-arm even after cooldown"
         );
         assert_eq!(d.reason, "zero-bounce-oscillation-suppressed");
+    }
+
+    /// After a typing-indicator re-arm fires once, a second typing→message cycle
+    /// must NOT fire again — the re-arm is consumed (exhausted) per Notified entry.
+    /// This guards against the infinite-spam loop observed in production logs.
+    #[test]
+    fn test_typing_indicator_rearm_fires_only_once() {
+        // T=100: initial notification fires (Idle → Notified).
+        let mut state = NotifState::Idle;
+        let d = decide_notification(&mut state, 1, "", false, true, false, 100);
+        assert!(d.should_fire);
+
+        // T=106: typing indicator (count=0, is_typing=true) → ZeroPending{zero_from_typing=true,
+        //        prev_typing_rearm_exhausted=false}.
+        let d = decide_notification(&mut state, 0, "", false, true, true, 106);
+        assert!(!d.should_fire);
+
+        // T=112: message arrives, elapsed=12 ≥ 5 → first rearm fires.
+        let d = decide_notification(&mut state, 1, "", false, true, false, 112);
+        assert!(d.should_fire, "first rearm must fire");
+        assert_eq!(d.reason, "typing-indicator-rearm");
+        // State is now Notified{typing_rearm_exhausted=true}.
+
+        // T=118: another typing indicator → ZeroPending{prev_typing_rearm_exhausted=true}.
+        let d = decide_notification(&mut state, 0, "", false, true, true, 118);
+        assert!(!d.should_fire);
+
+        // T=124: another message, elapsed=12 ≥ 5 — but rearm is exhausted → must NOT fire.
+        let d = decide_notification(&mut state, 1, "", false, true, false, 124);
+        assert!(
+            !d.should_fire,
+            "second rearm must be blocked (exhausted=true)"
+        );
+        assert_eq!(d.reason, "zero-bounce-oscillation-suppressed");
+    }
+
+    /// A genuine count increase resets the exhausted flag so the NEXT typing→message
+    /// cycle is allowed to re-arm again (rearm is per-message, not per-session).
+    #[test]
+    fn test_typing_indicator_rearm_reset_by_count_increase() {
+        // T=100: initial notification.
+        let mut state = NotifState::Idle;
+        let d = decide_notification(&mut state, 1, "", false, true, false, 100);
+        assert!(d.should_fire);
+
+        // T=106: typing indicator.
+        let _ = decide_notification(&mut state, 0, "", false, true, true, 106);
+
+        // T=112: rearm fires (first time) → exhausted=true.
+        let d = decide_notification(&mut state, 1, "", false, true, false, 112);
+        assert!(d.should_fire);
+        assert_eq!(d.reason, "typing-indicator-rearm");
+
+        // T=114: genuine new message (count=2) → fires via count_increased,
+        //        resets exhausted to false.
+        let d = decide_notification(&mut state, 2, "", false, true, false, 114);
+        assert!(d.should_fire, "count_increased must fire");
+        assert_eq!(d.reason, "count-increased");
+        // State is now Notified{count=2, typing_rearm_exhausted=false}.
+
+        // T=120: typing indicator again.
+        let _ = decide_notification(&mut state, 0, "", false, true, true, 120);
+
+        // T=126: message returns — rearm is allowed again (exhausted was reset).
+        let d = decide_notification(&mut state, 1, "", false, true, false, 126);
+        assert!(
+            d.should_fire,
+            "rearm must be allowed after exhausted was reset by count_increased"
+        );
+        assert_eq!(d.reason, "typing-indicator-rearm");
     }
 
     /// Verify TYPING_REARM_SECS constant is within a sensible range.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2465,6 +2465,49 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
          AppleWebKit/537.36 (KHTML, like Gecko) \
          Chrome/120.0.0.0 Safari/537.36",
         )
+        // ------------------------------------------------------------------
+        // Phase G: Rust-side title-change unread-count detection.
+        //
+        // On Windows (WebView2) and Linux (WebKitGTK), Tauri v2 blocks
+        // invoke() from remote origins (https://www.messenger.com) at the
+        // WebView layer regardless of the capabilities `"remote"` block —
+        // that block is designed for iOS/Android, not desktop WebViews.
+        //
+        // This handler fires whenever document.title changes (via Wry's
+        // cross-platform title-changed hook) — no IPC, no origin checks.
+        // Messenger sets the title to "(N) Messenger" for N unread messages
+        // and back to "Messenger" when all are read.  Parsing that title
+        // gives us the unread count without JS→Rust IPC at all.
+        //
+        // On macOS (where invoke() already works) this also fires but
+        // NOTIF_STATE deduplication suppresses double-notifications when
+        // the same count is reported by both paths.
+        // ------------------------------------------------------------------
+        .on_document_title_changed(move |webview_window, title| {
+            // Parse "(N)" prefix — same logic as JS getUnreadCountFromTitle().
+            let count: u32 = title
+                .trim_start()
+                .strip_prefix('(')
+                .and_then(|s| s.split_once(')'))
+                .and_then(|(n, _)| n.parse::<u32>().ok())
+                .unwrap_or(0);
+            log::info!(
+                "[MessengerX][TitleChange] title={:?} parsed_count={}",
+                title,
+                count
+            );
+            let app = webview_window.app_handle().clone();
+            std::thread::spawn(move || {
+                if let Err(e) = crate::commands::update_unread_count(
+                    count,
+                    String::new(), // sender: not available from title
+                    String::new(), // activity_sig: no DOM access from Rust
+                    app,
+                ) {
+                    log::warn!("[MessengerX][TitleChange] update_unread_count error: {e}");
+                }
+            });
+        })
         // Navigation policy: allow Messenger / Facebook CDN domains;
         // open everything else in the system browser.
         .on_navigation(move |url| {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2491,17 +2491,47 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                 .and_then(|s| s.split_once(')'))
                 .and_then(|(n, _)| n.parse::<u32>().ok())
                 .unwrap_or(0);
+
+            // Parse sender from "(N) SENDER | Messenger" format.
+            //   "(1) Jouda | Messenger"  → "Jouda"
+            //   "(1) Messenger"          → ""  (inbox / no open conversation)
+            //   "Jouda píše!" / typing   → ""  (count==0, skipped)
+            let sender: String = if count > 0 {
+                title
+                    .trim_start()
+                    .strip_prefix('(')
+                    .and_then(|s| s.split_once(')'))
+                    .and_then(|(_, rest)| {
+                        rest.trim()
+                            .split_once(" | Messenger")
+                            .map(|(name, _)| name.trim().to_owned())
+                    })
+                    .filter(|s| !s.is_empty())
+                    .unwrap_or_default()
+            } else {
+                String::new()
+            };
+
+            // Detect typing indicator: count==0 AND title is not the plain
+            // "Messenger" (all-read) AND has no "(N)" prefix.
+            // Examples: "Jouda píše!", "Alice is typing…"
+            let is_typing_indicator = count == 0
+                && title.trim() != "Messenger"
+                && !title.trim_start().starts_with('(');
+
             log::info!(
-                "[MessengerX][TitleChange] title={:?} parsed_count={}",
+                "[MessengerX][TitleChange] title={:?} parsed_count={} sender={:?} is_typing={}",
                 title,
-                count
+                count,
+                sender,
+                is_typing_indicator,
             );
             let app = webview_window.app_handle().clone();
             std::thread::spawn(move || {
-                if let Err(e) = crate::commands::update_unread_count(
+                if let Err(e) = crate::commands::update_unread_count_from_title(
                     count,
-                    String::new(), // sender: not available from title
-                    String::new(), // activity_sig: no DOM access from Rust
+                    sender,
+                    is_typing_indicator,
                     app,
                 ) {
                     log::warn!("[MessengerX][TitleChange] update_unread_count error: {e}");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2513,11 +2513,16 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
             };
 
             // Detect typing indicator: count==0 AND title is not the plain
-            // "Messenger" (all-read) AND has no "(N)" prefix.
-            // Examples: "Jouda píše!", "Alice is typing…"
+            // "Messenger" (all-read) AND has no "(N)" prefix AND the title is
+            // not empty AND does not contain " | Messenger" (which indicates a
+            // background conversation tab title like "Alice | Messenger" —
+            // Bug 2 false positive) AND the title is not blank (Bug 3: empty
+            // title from WebKitWebProcess crash must not be classified as typing).
             let is_typing_indicator = count == 0
+                && !title.trim().is_empty()
                 && title.trim() != "Messenger"
-                && !title.trim_start().starts_with('(');
+                && !title.trim_start().starts_with('(')
+                && !title.contains(" | Messenger");
 
             log::info!(
                 "[MessengerX][TitleChange] title={:?} parsed_count={} sender={:?} is_typing={}",


### PR DESCRIPTION
## Problem

v1.3.25 shipped the `remote.urls` capability fix but Win11 + Linux still showed zero `[MessengerX][JS]` log lines (Phase F verification). Root cause: the `"remote": {"urls": [...]}` block in `capabilities/default.json` is an iOS/Android-only mechanism — it does not unblock `invoke()` from remote origins on Windows (WebView2) or Linux (WebKitGTK) desktop builds.

Additional issues found during Phase H analysis:
- Notifications showed no **sender name** (generic "New message" title)
- A **typing indicator** (`"Jouda píše!"`, `"Alice is typing…"`) drops the unread count to 0 and back — without re-arming, the follow-up message notification was silently swallowed
- Win11/Linux had no **taskbar/urgency-hint signal** when a notification fired (window in background)

---

## Solution

### Phase G — `on_document_title_changed` IPC bypass

Add `.on_document_title_changed` handler to the `WebviewWindowBuilder` chain (between `.user_agent` and `.on_navigation`).

- Fires via Wry native title-changed hook — no IPC, no origin checks, works on all 3 platforms
- Parses `(N)` prefix from `document.title` (`"(N) Messenger"` / `"(N) SENDER | Messenger"`)
- Calls `update_unread_count_from_title(count, sender, is_typing_indicator, app)` via `std::thread::spawn`
- On macOS where `invoke()` still works, `NOTIF_STATE` deduplication suppresses the duplicate

### Phase H — Fix A: sender parsing

`on_document_title_changed` now fully parses:
- **Sender**: strips `(N)` prefix, extracts `SENDER` from `"(N) SENDER | Messenger"` format
- **Typing indicator**: `count==0 && title != "Messenger" && !title.starts_with('(')` → locale-agnostic detection of `"Jouda píše!"`, `"Alice is typing…"`, etc.

### Phase H — Fix B: typing-indicator re-arm

- `TYPING_REARM_SECS = 5`: when a typing-indicator zeroes the count, the next returning count re-fires the notification if ≥5 s have elapsed since the last notification
- `ZeroPending.zero_from_typing` field tracks the trigger source
- `update_unread_count` split into 3 functions preserving JS IPC API unchanged

### Phase H — Fix D: taskbar / urgency-hint attention

- `#[cfg(not(target_os = "macos"))]` block in `update_unread_count_core` (section 3b)
- When `decision.should_fire`: calls `w.request_user_attention(Some(tauri::UserAttentionType::Informational))`
- **Win11**: amber taskbar button highlight, stays until window is focused
- **Linux**: window urgency hint (compositor-dependent visual)
- macOS excluded — Dock badge (section 3) is sufficient

---

## Changes

| File | Change |
|------|--------|
| `src-tauri/src/lib.rs` | Phase G: `on_document_title_changed` handler; Phase H Fix A: sender + typing-indicator parsing |
| `src-tauri/src/commands.rs` | Phase H Fix B: `TYPING_REARM_SECS`, `ZeroPending.zero_from_typing`, 3-function split, `typing_rearm` path, 4 new tests; Fix D: `request_user_attention` section 3b |

---

## Checks

- `cargo clippy --all-targets -- -D warnings`: **PASS**
- `cargo test --lib`: **37/37 PASS** (4 new typing-rearm tests)
- `npx tsc --noEmit`: **PASS**

---

## Verification

Tracked in issue #20 — install debug build from Test Build CI artifacts, verify on Win11 + Linux:
1. `[MessengerX][TitleChange]` lines with `sender=` and `is_typing=` appear in log
2. Notification banner fires with **sender name** (not generic "New message")
3. **Taskbar button highlights** on Win11 / urgency hint on Linux when notification fires
4. Typing indicator → message sequence produces a notification for the message
5. macOS: no duplicate banners (regression check)