### PR TITLE
fix(notifications): drop wrong sender name from title handler (Win11/Linux)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2492,25 +2492,14 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                 .and_then(|(n, _)| n.parse::<u32>().ok())
                 .unwrap_or(0);
 
-            // Parse sender from "(N) SENDER | Messenger" format.
-            //   "(1) Jouda | Messenger"  → "Jouda"
-            //   "(1) Messenger"          → ""  (inbox / no open conversation)
-            //   "Jouda píše!" / typing   → ""  (count==0, skipped)
-            let sender: String = if count > 0 {
-                title
-                    .trim_start()
-                    .strip_prefix('(')
-                    .and_then(|s| s.split_once(')'))
-                    .and_then(|(_, rest)| {
-                        rest.trim()
-                            .split_once(" | Messenger")
-                            .map(|(name, _)| name.trim().to_owned())
-                    })
-                    .filter(|s| !s.is_empty())
-                    .unwrap_or_default()
-            } else {
-                String::new()
-            };
+            // Do NOT extract sender from "(N) SENDER | Messenger" — SENDER is the
+            // *currently open* conversation, not the author of the new message.
+            // Example: user has "Karel Novák" open; "Jouda" sends a message →
+            // title becomes "(1) Karel Novák | Messenger" → wrong sender.
+            // The JS IPC path (macOS) correctly uses getFirstUnreadSenderName()
+            // which reads the actual unread entry from the DOM sidebar.
+            // On Win11/Linux we fall back to the generic "Nová zpráva" string.
+            let sender = String::new();
 
             // Detect typing indicator: count==0 AND title is not the plain
             // "Messenger" (all-read) AND has no "(N)" prefix AND the title is


### PR DESCRIPTION
## Problem

On Win11 (and Linux), notifications showed the wrong sender name — the **currently open conversation** instead of the actual message author.

**Root cause:** The `SENDER` in `(N) SENDER | Messenger` window title is the *active/open* conversation tab, not the new message author. Example: user has Karel Novak open, Jouda writes → title is `(1) Karel Novak | Messenger` → wrong sender extracted.

## Fix

Drop sender extraction from the Rust `on_document_title_changed` handler. Always emit `sender = ""` from this path. Notifications fall back to the generic "Nova zprava / New message" translation.

macOS is unaffected — it uses the JS IPC path (`getFirstUnreadSenderName()`) which reads the actual unread entry from the DOM sidebar.

## Checks
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test --lib` 39/39 ✅
- `npx tsc --noEmit` ✅