### PR TITLE
fix(linux+win11): WPAD builder API, tauri.localhost nav, crash recovery, GNOME toast/MPRIS suppression

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2363,6 +2363,11 @@ fn log_platform_environment() {
             let stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
             log::info!("[MessengerX][Env][Windows] webview2_runtime_query={stdout:?}");
         }
+        // Verify WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS is set so we can confirm
+        // the env-var WPAD-fix is actually inherited by the WebView2 process.
+        let wv2_args = std::env::var("WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS")
+            .unwrap_or_else(|_| "<not set>".to_string());
+        log::info!("[MessengerX][Env][Windows] WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS={wv2_args:?}");
     }
 
     #[cfg(target_os = "macos")]
@@ -2629,12 +2634,20 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         "[MessengerX][Boot][Trace] startup_url decision: last_raw={last_url_raw:?} \
          safe={last_url_safe} chosen={startup_url:?}"
     );
-    let webview_url = if is_online {
-        log::info!("[MessengerX][Boot] initial_url={startup_url}");
-        WebviewUrl::External(url::Url::parse(startup_url)?)
+    // When online, start with the local loading.html so the window shows a
+    // spinner immediately (instead of a blank white screen) while WebView2
+    // initialises its network stack.  After build() we navigate to the real
+    // messenger.com URL in a background thread.  WebView2 keeps the previous
+    // page visible until ContentLoading fires for the new navigation, so the
+    // spinner stays on-screen for the entire ~27 s network-init gap.
+    // When offline, go straight to index.html (the offline fallback) as before.
+    let (webview_url, navigate_after_build) = if is_online {
+        log::info!("[MessengerX][Boot] initial_url={startup_url} (via loading.html splash)");
+        let target_url = url::Url::parse(startup_url)?;
+        (WebviewUrl::App("loading.html".into()), Some(target_url))
     } else {
         log::info!("[MessengerX] Offline at startup — loading local fallback page");
-        WebviewUrl::App("index.html".into())
+        (WebviewUrl::App("index.html".into()), None)
     };
 
     // Build the scrollbar-fix script with platform-specific behaviour.
@@ -3102,6 +3115,29 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         "[MessengerX][Boot][Trace] WebviewWindowBuilder.build elapsed={}ms",
         webview_build_started.elapsed().as_millis()
     );
+
+    // ------------------------------------------------------------------
+    // 4a-loading. If we started with the local loading.html splash page,
+    //   navigate to the real messenger.com URL now in a background thread.
+    //
+    //   A short delay (100 ms) gives the WebView time to paint the spinner
+    //   before we trigger the network navigation.  Without the delay, the
+    //   navigate() call races with the initial paint and the spinner may
+    //   never be visible.  100 ms is imperceptible to the user but long
+    //   enough for the compositor to flush the first frame.
+    // ------------------------------------------------------------------
+    if let Some(target_url) = navigate_after_build {
+        let navigate_webview = webview.clone();
+        log::info!(
+            "[MessengerX][Boot] scheduling navigate to {target_url} after 100ms splash delay"
+        );
+        std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            if let Err(e) = navigate_webview.navigate(target_url) {
+                log::warn!("[MessengerX][Boot] post-build navigate failed: {e}");
+            }
+        });
+    }
 
     // ------------------------------------------------------------------
     // 4b. Apply persisted zoom level via the native WebView API.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2204,6 +2204,44 @@ const VISIBILITY_OVERRIDE_SCRIPT: &str = r#"(function() {
     jlog('visibility override installed');
 })();"#;
 
+/// Linux: suppress the GNOME MPRIS "Now Playing" media-player widget.
+///
+/// WebKitGTK implements the W3C Media Session API and automatically
+/// publishes any `navigator.mediaSession.metadata` (title, artist, …) to
+/// D-Bus via its MPRIS interface.  GNOME Shell subscribes to this interface
+/// and displays a media-player control widget in the notification shade that
+/// shows Messenger conversation titles / contact names.
+///
+/// This script replaces `navigator.mediaSession` with a no-op proxy at
+/// document-start, before Messenger's scripts run.  The replacement is
+/// API-compatible (all properties and methods exist) so Messenger does not
+/// throw errors — it simply cannot propagate metadata to D-Bus.
+///
+/// Audio and video calls are unaffected: WebRTC / Web Audio API handle the
+/// actual media routing and do not go through MediaSession.
+#[cfg(target_os = "linux")]
+const MEDIA_SESSION_SUPPRESS_SCRIPT: &str = r#"(function() {
+    try {
+        var _dummySession = {
+            get metadata() { return null; },
+            set metadata(v) { /* drop — prevent D-Bus/MPRIS broadcast */ },
+            get playbackState() { return 'none'; },
+            set playbackState(v) { /* drop */ },
+            setActionHandler: function() {},
+            setPositionState: function() {},
+            setCameraActive: function() {},
+            setMicrophoneActive: function() {},
+        };
+        Object.defineProperty(navigator, 'mediaSession', {
+            get: function() { return _dummySession; },
+            configurable: true,
+        });
+    } catch (e) {
+        // Swallow: if the override fails the only consequence is that the
+        // GNOME MPRIS widget may still appear.
+    }
+})();"#;
+
 /// Persists the current Unix timestamp (seconds) as `last_update_check_secs`
 /// in the user's settings file.
 ///
@@ -2694,6 +2732,28 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(target_os = "linux")]
     let builder = builder.initialization_script(VISIBILITY_OVERRIDE_SCRIPT);
 
+    // On Linux, suppress the GNOME MPRIS media-player widget that would
+    // otherwise display Messenger conversation titles / contact names in the
+    // notification shade.  See MEDIA_SESSION_SUPPRESS_SCRIPT doc comment.
+    #[cfg(target_os = "linux")]
+    let builder = builder.initialization_script(MEDIA_SESSION_SUPPRESS_SCRIPT);
+
+    // On Windows, pass Chromium flags directly via the WebviewWindowBuilder
+    // `additional_browser_args` API.  This is the *only* reliable way to reach
+    // WebView2's AdditionalBrowserArguments setting — the env-var approach
+    // (WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS) is silently overridden by WRY
+    // when it calls CreateCoreWebView2EnvironmentWithOptions.
+    //
+    // --proxy-auto-detect=0          Disables WPAD (Web Proxy Auto-Discovery)
+    //                                which causes a ~21 s stall on Windows
+    //                                "Public" network profiles that trigger
+    //                                WPAD by default.
+    // --disable-background-networking Turns off speculative prefetch/DNS/OCSP
+    //                                  probes that can also add latency at boot.
+    #[cfg(target_os = "windows")]
+    let builder = builder
+        .additional_browser_args("--proxy-auto-detect=0 --disable-background-networking");
+
     let webview = builder
         // Spoof a desktop Chrome UA so Messenger serves its full web-app.
         .user_agent(
@@ -2947,8 +3007,32 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                     } else {
                         log::warn!(
                             "[MessengerX][CrashDetect] Max crash reloads ({MAX_CRASH_RELOADS}) \
-                             reached — not reloading again this session."
+                             reached — navigating to messenger.com root to restore usability."
                         );
+                        // Navigate to root so the user is not left with a
+                        // blank / crashed window.  We do not increment the
+                        // reload counter here — this is a recovery navigation,
+                        // not another crash-triggered reload.
+                        let wv = webview_window.clone();
+                        std::thread::spawn(move || {
+                            std::thread::sleep(std::time::Duration::from_secs(2));
+                            match url::Url::parse("https://www.messenger.com/") {
+                                Ok(u) => {
+                                    if let Err(e) = wv.navigate(u) {
+                                        log::warn!(
+                                            "[MessengerX][CrashDetect] recovery navigate() \
+                                             failed: {e}"
+                                        );
+                                    }
+                                }
+                                Err(e) => {
+                                    log::warn!(
+                                        "[MessengerX][CrashDetect] recovery URL parse \
+                                         failed: {e}"
+                                    );
+                                }
+                            }
+                        });
                     }
                 }
             }
@@ -2985,6 +3069,14 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                 }
 
                 let host = url.host_str().unwrap_or("");
+
+                // Pass through Tauri's own local asset server (tauri.localhost on
+                // Windows / WebView2).  It uses the http scheme, so the scheme
+                // check above does not catch it, and it must never be treated as
+                // an external URL or opened in the system browser.
+                if host == "tauri.localhost" || host == "localhost" {
+                    return true;
+                }
                 log::info!(
                     "[MessengerX] on_navigation: host={host} url={url} t={}ms",
                     setup_started.elapsed().as_millis()

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -80,25 +80,39 @@ fn main() {
 }
 
 // -----------------------------------------------------------------------
-// Windows: suppress WPAD proxy auto-detection to eliminate the ~27-second
-// stall on first navigation.
+// Windows: suppress WPAD proxy auto-detection and background networking
+// to eliminate the ~27-second stall on first navigation.
 //
-// WebView2 inherits WinHTTP proxy settings including "Automatically detect
-// settings" (WPAD / DHCP Option 252 + DNS wpad.*).  On networks that do
-// not run a WPAD server the discovery attempt times out after ~27 seconds
-// before WebView2 falls back to DIRECT.  This manifests as a white window
-// on every app launch.
+// Root-cause investigation history:
 //
-// `--proxy-auto-detect=0` (Chromium flag forwarded to the WebView2 child
-// process via WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS) disables automatic
-// proxy discovery while still honouring any manually configured proxy in
-// Windows Settings → Proxy → Manual proxy setup.  Corporate users who
-// configure a proxy explicitly are unaffected; only WPAD/PAC-script
-// auto-discovery is disabled.
+//   Hypothesis 1 (WPAD): WebView2 inherits WinHTTP "Automatically detect
+//   settings" (WPAD / DHCP Option 252 + DNS wpad.*).  On networks without
+//   a WPAD server the discovery attempt times out after ~27 s before
+//   WebView2 falls back to DIRECT.  `--proxy-auto-detect=0` disables it.
+//   Corporate users with manual proxy settings are unaffected.
+//
+//   Hypothesis 2 (background networking): WebView2 performs background
+//   probes at startup (captive-portal checks, Safe Browsing, OCSP/CT logs)
+//   that may also serialize on the network stack for ~27 s.
+//   `--disable-background-networking` disables these Chromium background
+//   services while leaving the main page fetch unaffected.
+//
+// Both flags are combined here so a single v1.3.32 log can distinguish:
+//   - If gap disappears → background-networking was the culprit (WPAD flag
+//     alone in v1.3.31 did not help, or the env-var was silently dropped
+//     by WRY overriding AdditionalBrowserArguments internally).
+//   - If gap persists → neither WPAD nor background-networking is the cause;
+//     look at WebView2 network-service process startup or IPv6 happy-eyeballs.
 //
 // The env var must be set before WebView2 spawns its browser process,
 // which happens inside `messengerx_lib::run()`.  Setting it here in main()
 // before that call is the correct placement.
+//
+// NOTE: `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` is only honoured when
+// `AdditionalBrowserArguments` is NOT set explicitly in
+// `CreateCoreWebView2EnvironmentWithOptions`.  If WRY passes an explicit
+// empty string there the env var is ignored; the [Env][Windows] log line
+// added to setup_app confirms whether the var survives into the process.
 // -----------------------------------------------------------------------
 #[cfg(target_os = "windows")]
 fn set_webview2_no_proxy_auto_detect() {
@@ -106,6 +120,6 @@ fn set_webview2_no_proxy_auto_detect() {
     // std::env::set_var is safe at this point.
     std::env::set_var(
         "WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS",
-        "--proxy-auto-detect=0",
+        "--proxy-auto-detect=0 --disable-background-networking",
     );
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -76,7 +76,36 @@ fn main() {
     #[cfg(target_os = "windows")]
     set_webview2_no_proxy_auto_detect();
 
+    // On Linux, remove the XDG startup-notification environment variables
+    // before WRY/GTK reads them.  Without these vars GTK will not send a
+    // startup-completion signal on the session bus, so GNOME Shell never shows
+    // its "Připraveno 'AppName'" ("Ready 'AppName'") startup toast.
+    //
+    // Removing the vars is safe: they are only consumed by GTK for the startup
+    // animation hint and play no role in networking, IPC, or window management.
+    // The only visible side-effect is that the GNOME launcher's zoom-in
+    // animation does not animate the window from the launcher icon — acceptable
+    // for a system-tray application.
+    #[cfg(target_os = "linux")]
+    suppress_gnome_startup_notification();
+
     messengerx_lib::run()
+}
+
+/// On Linux, clear XDG startup-notification environment variables so that
+/// GNOME Shell does not display a "Připraveno 'Messenger X'" ("Ready 'AppName'")
+/// toast when the app window first appears.
+///
+/// GNOME Shell shows this toast in response to the GTK startup-completion
+/// signal (`_NET_STARTUP_INFO` on X11 / `xdg-activation` on Wayland).
+/// WRY/GTK reads `DESKTOP_STARTUP_ID` (X11) and `XDG_ACTIVATION_TOKEN`
+/// (Wayland) at window-creation time to produce that signal.  Clearing both
+/// vars before `messengerx_lib::run()` prevents the signal from being sent.
+#[cfg(target_os = "linux")]
+fn suppress_gnome_startup_notification() {
+    // Safety: called once before any other threads are spawned.
+    std::env::remove_var("DESKTOP_STARTUP_ID");
+    std::env::remove_var("XDG_ACTIVATION_TOKEN");
 }
 
 // -----------------------------------------------------------------------

--- a/src/loading.html
+++ b/src/loading.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Messenger X</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 100vh;
+      background: #f0f2f5;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      color: #65676b;
+    }
+    .container {
+      text-align: center;
+    }
+    .logo {
+      width: 64px;
+      height: 64px;
+      border-radius: 50%;
+      background: linear-gradient(135deg, #0084ff 0%, #9b59b6 100%);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin: 0 auto 20px;
+      position: relative;
+    }
+    /* Chat-bubble icon inside the gradient circle */
+    .logo::after {
+      content: '';
+      width: 32px;
+      height: 32px;
+      background: white;
+      border-radius: 50%;
+      clip-path: polygon(
+        0% 0%, 100% 0%, 100% 75%,
+        60% 75%, 40% 100%, 40% 75%,
+        0% 75%
+      );
+    }
+    .title {
+      font-size: 20px;
+      font-weight: 600;
+      color: #050505;
+      margin-bottom: 12px;
+    }
+    .spinner {
+      width: 28px;
+      height: 28px;
+      border: 3px solid #d8dadf;
+      border-top-color: #0084ff;
+      border-radius: 50%;
+      animation: spin 0.8s linear infinite;
+      margin: 0 auto;
+    }
+    @keyframes spin {
+      to { transform: rotate(360deg); }
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="logo"></div>
+    <div class="title">Messenger X</div>
+    <div class="spinner"></div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- **Fix 1 (Win11):** `on_navigation` early return for `tauri.localhost`/`localhost` — prevents `loading.html` from opening in Edge browser
- **Fix 2 (Win11):** `WebviewWindowBuilder::additional_browser_args("--proxy-auto-detect=0 --disable-background-networking")` — only reliable path to WebView2 `AdditionalBrowserArguments`; env var approach overridden by WRY
- **Fix 3 (Linux):** Post-max-crash recovery navigation — after 3× GStreamer crashes navigate to `messenger.com` root instead of leaving blank window
- **Fix 4 (Linux):** Remove `DESKTOP_STARTUP_ID` + `XDG_ACTIVATION_TOKEN` before `run()` — suppresses GNOME Shell "Připraveno 'Messenger X'" startup toast
- **Fix 5 (Linux):** `MEDIA_SESSION_SUPPRESS_SCRIPT` initialization_script replaces `navigator.mediaSession` with no-op proxy — suppresses GNOME MPRIS "Now Playing" widget showing conversation titles

## Checks

`cargo clippy --all-targets -- -D warnings` ✅  `cargo test --lib` 52/52 ✅  `npx tsc --noEmit` ✅  `git diff --check` ✅