### PR TITLE
fix(linux): robust MPRIS suppression + StartupNotify=false in .desktop template

### DIFF
--- a/src-tauri/messengerx.desktop.hbs
+++ b/src-tauri/messengerx.desktop.hbs
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Categories={{categories}}
+{{#if comment}}Comment={{comment}}
+{{/if}}Exec={{exec}}
+Icon={{icon}}
+Name={{name}}
+Terminal=false
+Type=Application
+StartupNotify=false

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2217,28 +2217,55 @@ const VISIBILITY_OVERRIDE_SCRIPT: &str = r#"(function() {
 /// API-compatible (all properties and methods exist) so Messenger does not
 /// throw errors — it simply cannot propagate metadata to D-Bus.
 ///
+/// Override strategy (belt-and-suspenders):
+///   1. Define a frozen no-op object as the replacement.
+///   2. Try `Object.defineProperty` on `Navigator.prototype` first —
+///      in WebKitGTK the attribute is defined on the prototype, so this
+///      intercepts all `navigator.mediaSession` accesses immediately.
+///      Using `configurable: false` prevents page code from re-overriding.
+///   3. Fall back to the `navigator` instance if the prototype override
+///      throws (e.g. already non-configurable on the prototype).
+///   4. Log a console.warn if both paths fail so future debugging is easier.
+///
 /// Audio and video calls are unaffected: WebRTC / Web Audio API handle the
 /// actual media routing and do not go through MediaSession.
 #[cfg(target_os = "linux")]
 const MEDIA_SESSION_SUPPRESS_SCRIPT: &str = r#"(function() {
+    'use strict';
+    var _noop = Object.freeze({
+        metadata: null,
+        playbackState: 'none',
+        setActionHandler: function() {},
+        setPositionState: function() {},
+        setCameraActive: function() {},
+        setMicrophoneActive: function() {},
+    });
+    var _descriptor = {
+        get: function() { return _noop; },
+        set: function() { /* drop assignment — prevent re-override by page code */ },
+        configurable: false,
+        enumerable: false,
+    };
+    var _overridden = false;
+    // Strategy 1: override on the prototype (preferred — covers all instances).
     try {
-        var _dummySession = {
-            get metadata() { return null; },
-            set metadata(v) { /* drop — prevent D-Bus/MPRIS broadcast */ },
-            get playbackState() { return 'none'; },
-            set playbackState(v) { /* drop */ },
-            setActionHandler: function() {},
-            setPositionState: function() {},
-            setCameraActive: function() {},
-            setMicrophoneActive: function() {},
-        };
-        Object.defineProperty(navigator, 'mediaSession', {
-            get: function() { return _dummySession; },
-            configurable: true,
-        });
-    } catch (e) {
-        // Swallow: if the override fails the only consequence is that the
-        // GNOME MPRIS widget may still appear.
+        Object.defineProperty(Navigator.prototype, 'mediaSession', _descriptor);
+        _overridden = true;
+    } catch (_protoErr) {
+        // Prototype override failed; fall through to instance override.
+    }
+    // Strategy 2: override on the navigator instance as a fallback.
+    if (!_overridden) {
+        try {
+            Object.defineProperty(navigator, 'mediaSession', _descriptor);
+            _overridden = true;
+        } catch (_instanceErr) {
+            // Both overrides failed.
+        }
+    }
+    if (!_overridden) {
+        // eslint-disable-next-line no-console
+        console.warn('[MX] mediaSession override failed — GNOME MPRIS widget may still appear');
     }
 })();"#;
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -77,30 +77,34 @@ fn main() {
     set_webview2_no_proxy_auto_detect();
 
     // On Linux, remove the XDG startup-notification environment variables
-    // before WRY/GTK reads them.  Without these vars GTK will not send a
-    // startup-completion signal on the session bus, so GNOME Shell never shows
-    // its "Připraveno 'AppName'" ("Ready 'AppName'") startup toast.
+    // before WRY/GTK reads them.
     //
-    // Removing the vars is safe: they are only consumed by GTK for the startup
-    // animation hint and play no role in networking, IPC, or window management.
-    // The only visible side-effect is that the GNOME launcher's zoom-in
-    // animation does not animate the window from the launcher icon — acceptable
-    // for a system-tray application.
+    // On X11 this prevents GTK3 from sending a `_NET_STARTUP_INFO` completion
+    // message, which stops GNOME Shell from showing a "Ready 'AppName'" toast.
+    //
+    // On Wayland, GNOME Shell tracks startup via PID / WM_CLASS correlation
+    // independently of these env vars, so this call alone is not sufficient.
+    // The primary fix for Wayland is `StartupNotify=false` in the bundled
+    // `.desktop` file (set via `bundle.linux.deb.desktopTemplate` in
+    // tauri.conf.json), which tells GNOME Shell not to track this app's
+    // startup at all.
+    //
+    // Removing the vars is safe: they are only consumed by GTK for startup
+    // animation hints and play no role in networking, IPC, or window management.
     #[cfg(target_os = "linux")]
     suppress_gnome_startup_notification();
 
     messengerx_lib::run()
 }
 
-/// On Linux, clear XDG startup-notification environment variables so that
-/// GNOME Shell does not display a "Připraveno 'Messenger X'" ("Ready 'AppName'")
-/// toast when the app window first appears.
+/// On Linux, clear XDG startup-notification environment variables.
 ///
-/// GNOME Shell shows this toast in response to the GTK startup-completion
-/// signal (`_NET_STARTUP_INFO` on X11 / `xdg-activation` on Wayland).
-/// WRY/GTK reads `DESKTOP_STARTUP_ID` (X11) and `XDG_ACTIVATION_TOKEN`
-/// (Wayland) at window-creation time to produce that signal.  Clearing both
-/// vars before `messengerx_lib::run()` prevents the signal from being sent.
+/// Effective on X11: prevents GTK3 from sending the `_NET_STARTUP_INFO`
+/// completion signal, suppressing the GNOME "Ready 'AppName'" toast.
+///
+/// On Wayland the primary suppression is `StartupNotify=false` in the
+/// bundled `.desktop` file; this function provides additional defence-in-depth
+/// by removing `XDG_ACTIVATION_TOKEN` before GTK3 initialises.
 #[cfg(target_os = "linux")]
 fn suppress_gnome_startup_notification() {
     // Safety: called once before any other threads are spawned.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -43,7 +43,8 @@
           "gstreamer1.0-plugins-good"
         ],
         "section": "web",
-        "priority": "optional"
+        "priority": "optional",
+        "desktopTemplate": "messengerx.desktop.hbs"
       },
       "appimage": {
         "bundleMediaFramework": true,


### PR DESCRIPTION
## Summary

Regression fixes for v1.3.33 — both Linux fixes failed silently and are corrected here.

### Fix 5b — MPRIS media-player widget
- **Root cause:** `Object.defineProperty(navigator, 'mediaSession', {configurable: true})` threw a TypeError because WebKitGTK defines `mediaSession` as non-configurable on the `navigator` instance. Error was swallowed → MPRIS widget still appeared.
- **Fix:** Override `Navigator.prototype.mediaSession` with `configurable: false` (intercepts all access at prototype level, prevents page code from re-overriding). Falls back to instance override if prototype throws. Adds `console.warn` if both fail.

### Fix 4b — GNOME startup toast ("Připraveno 'Messenger X'")
- **Root cause:** Removing `DESKTOP_STARTUP_ID` + `XDG_ACTIVATION_TOKEN` env vars only works on X11. On Wayland, GNOME Shell tracks startup via PID/WM_CLASS correlation, independent of env vars → toast still appeared.
- **Fix:** Added `src-tauri/messengerx.desktop.hbs` Handlebars template with `StartupNotify=false` and wired via `bundle.linux.deb.desktopTemplate` in `tauri.conf.json`. Env var removal kept as defence-in-depth for X11.

## Checks

`cargo clippy --all-targets -- -D warnings` ✅  `cargo test --lib` 52/52 ✅  `npx tsc --noEmit` ✅  `git diff --check` ✅