### PR TITLE
fix: logout clears snapshots + WebView cookies/storage

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5253,6 +5253,28 @@ mod tests {
         }
     }
 
+    mod logout_handlers {
+        const SOURCE: &str = include_str!("lib.rs");
+
+        #[test]
+        fn both_logout_handlers_clear_snapshots() {
+            assert!(
+                SOURCE.contains("services::cache::clear_snapshots(handle)")
+                    && SOURCE.contains("services::cache::clear_snapshots(&h)"),
+                "both tray and macOS logout handlers must clear snapshots"
+            );
+        }
+
+        #[test]
+        fn both_logout_handlers_use_shared_logout_script() {
+            assert_eq!(
+                SOURCE.matches("wv.eval(LOGOUT_CLEAR_SCRIPT)").count(),
+                2,
+                "both tray and macOS logout handlers must eval LOGOUT_CLEAR_SCRIPT"
+            );
+        }
+    }
+
     #[cfg(target_os = "linux")]
     mod linux_runtime {
         use super::super::{configure_linux_runtime_env, LINUX_APPIMAGE_ENV_OVERRIDES};

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2219,6 +2219,38 @@ const SNAPSHOT_TRIGGER_SCRIPT: &str = r#"
 })();
 "#;
 
+/// JavaScript snippet injected via `eval()` during logout.  Clears all
+/// accessible cookies (with proper subdomain handling), localStorage,
+/// sessionStorage, then navigates to `https://www.messenger.com`.
+///
+/// * Cookie names are trimmed after splitting on `;`.
+/// * Empty cookie names are skipped (guards against `document.cookie === ''`).
+/// * Cookie expiry uses RFC1123 GMT format for cross-WebView compatibility.
+/// * The `while` loop stops before the TLD (`hostParts.length > 1`).
+/// * Any storage error is caught so the redirect always runs in `finally`.
+const LOGOUT_CLEAR_SCRIPT: &str = r#"
+try {
+    document.cookie.split(';').forEach(function(c) {
+        var eq = c.indexOf('=');
+        var name = (eq > -1 ? c.substring(0, eq) : c).trim();
+        if (!name) return;
+        var hostParts = window.location.hostname.split('.');
+        while (hostParts.length > 1) {
+            var domain = hostParts.join('.');
+            document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/;domain=' + domain;
+            document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/;domain=.' + domain;
+            hostParts.shift();
+        }
+        document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/';
+    });
+} catch (e) {} finally {
+    try { localStorage.clear(); } catch (e) {}
+    try { sessionStorage.clear(); } catch (e) {}
+    try { sessionStorage.setItem('__mx_appearance', 'system'); } catch (e) {}
+    window.location.href = 'https://www.messenger.com';
+}
+"#;
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -4404,7 +4436,9 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
 
                     // ---- Log out & clear data ----
                     "logout" => {
-                        let _ = services::cache::clear_snapshots(handle);
+                        if let Err(e) = services::cache::clear_snapshots(handle) {
+                            log::warn!("[MessengerX] Failed to clear snapshots during logout: {e}");
+                        }
                         let defaults = crate::commands::AppSettings::default();
                         let _ = services::auth::save_settings(handle, &defaults);
 
@@ -4443,27 +4477,7 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                         // before navigating to messenger.com so Facebook's login
                         // session is actually dropped.
                         if let Some(wv) = handle.get_webview_window("main") {
-                            let _ = wv.eval(
-                                "try{\
-                                 document.cookie.split(';').forEach(function(c){\
-                                  var eq=c.indexOf('=');\
-                                  var name=(eq>-1?c.substring(0,eq):c).trim();\
-                                  var hostParts=window.location.hostname.split('.');\
-                                  while(hostParts.length>1){\
-                                   var domain=hostParts.join('.');\
-                                   document.cookie=name+'=;expires=Thu,01 Jan 1970 00:00:00 UTC;path=/;domain='+domain;\
-                                   document.cookie=name+'=;expires=Thu,01 Jan 1970 00:00:00 UTC;path=/;domain=.'+domain;\
-                                   hostParts.shift();\
-                                  }\
-                                  document.cookie=name+'=;expires=Thu,01 Jan 1970 00:00:00 UTC;path=/';\
-                                 });\
-                                 }catch(e){}finally{\
-                                 try{localStorage.clear();}catch(e){}\
-                                 try{sessionStorage.clear();}catch(e){}\
-                                 try{sessionStorage.setItem('__mx_appearance','system');}catch(e){}\
-                                 window.location.href='https://www.messenger.com';\
-                                 }",
-                            );
+                            let _ = wv.eval(LOGOUT_CLEAR_SCRIPT);
                             let _ = wv.show();
                             let _ = wv.set_focus();
                         }
@@ -4913,7 +4927,9 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
 
                 // ---- Log out & clear data ----
                 "logout" => {
-                    let _ = services::cache::clear_snapshots(&h);
+                    if let Err(e) = services::cache::clear_snapshots(&h) {
+                        log::warn!("[MessengerX] Failed to clear snapshots during logout: {e}");
+                    }
                     let defaults = commands::AppSettings::default();
                     let _ = services::auth::save_settings(&h, &defaults);
 
@@ -4950,27 +4966,7 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                     // Clear WebView cookies / localStorage / sessionStorage
                     // before navigating to messenger.com.
                     if let Some(wv) = h.get_webview_window("main") {
-                        let _ = wv.eval(
-                            "try{\
-                             document.cookie.split(';').forEach(function(c){\
-                              var eq=c.indexOf('=');\
-                              var name=(eq>-1?c.substring(0,eq):c).trim();\
-                              var hostParts=window.location.hostname.split('.');\
-                              while(hostParts.length>1){\
-                               var domain=hostParts.join('.');\
-                               document.cookie=name+'=;expires=Thu,01 Jan 1970 00:00:00 UTC;path=/;domain='+domain;\
-                               document.cookie=name+'=;expires=Thu,01 Jan 1970 00:00:00 UTC;path=/;domain=.'+domain;\
-                               hostParts.shift();\
-                              }\
-                              document.cookie=name+'=;expires=Thu,01 Jan 1970 00:00:00 UTC;path=/';\
-                             });\
-                             }catch(e){}finally{\
-                             try{localStorage.clear();}catch(e){}\
-                             try{sessionStorage.clear();}catch(e){}\
-                             try{sessionStorage.setItem('__mx_appearance','system');}catch(e){}\
-                             window.location.href='https://www.messenger.com';\
-                             }",
-                        );
+                        let _ = wv.eval(LOGOUT_CLEAR_SCRIPT);
                         let _ = wv.show();
                         let _ = wv.set_focus();
                     }
@@ -5395,6 +5391,88 @@ mod tests {
             assert!(
                 VISIBILITY_OVERRIDE_SCRIPT.contains("get_window_focused"),
                 "script must invoke get_window_focused to resync state on each navigation"
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Logout script regression tests
+    // -----------------------------------------------------------------------
+    mod logout_script {
+        use super::super::LOGOUT_CLEAR_SCRIPT;
+
+        /// The script must attempt to clear cookies (the core privacy action).
+        #[test]
+        fn clears_cookies() {
+            assert!(
+                LOGOUT_CLEAR_SCRIPT.contains("document.cookie"),
+                "logout script must touch document.cookie"
+            );
+        }
+
+        /// The script must clear localStorage and sessionStorage.
+        #[test]
+        fn clears_storage() {
+            assert!(
+                LOGOUT_CLEAR_SCRIPT.contains("localStorage.clear()"),
+                "logout script must clear localStorage"
+            );
+            assert!(
+                LOGOUT_CLEAR_SCRIPT.contains("sessionStorage.clear()"),
+                "logout script must clear sessionStorage"
+            );
+        }
+
+        /// The script must reset the appearance override key in sessionStorage
+        /// so the next login page shows the correct theme.
+        #[test]
+        fn resets_appearance_key() {
+            assert!(
+                LOGOUT_CLEAR_SCRIPT.contains("__mx_appearance"),
+                "logout script must reset __mx_appearance"
+            );
+        }
+
+        /// The script must navigate to messenger.com after clearing.
+        #[test]
+        fn navigates_to_messenger() {
+            assert!(
+                LOGOUT_CLEAR_SCRIPT.contains("https://www.messenger.com"),
+                "logout script must redirect to messenger.com"
+            );
+        }
+
+        /// Cookie expiry must use the RFC1123 GMT format (not UTC) for
+        /// cross-WebView compatibility.
+        #[test]
+        fn cookie_expiry_uses_gmt() {
+            assert!(
+                LOGOUT_CLEAR_SCRIPT.contains("00:00:00 GMT"),
+                "cookie expiry must use GMT format"
+            );
+            assert!(
+                !LOGOUT_CLEAR_SCRIPT.contains("00:00:00 UTC"),
+                "cookie expiry must not use UTC format"
+            );
+        }
+
+        /// The cookie loop must guard against empty cookie names so that
+        /// `document.cookie === ''` does not generate invalid assignments.
+        #[test]
+        fn skips_empty_cookie_names() {
+            assert!(
+                LOGOUT_CLEAR_SCRIPT.contains("if (!name) return"),
+                "logout script must skip empty cookie names"
+            );
+        }
+
+        /// The cookie-domain loop must stop before the TLD to avoid
+        /// assigning cookies to e.g. `domain=com`.
+        #[test]
+        fn stops_before_tld() {
+            assert!(
+                LOGOUT_CLEAR_SCRIPT.contains("hostParts.length > 1"),
+                "cookie loop must stop before TLD"
             );
         }
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2219,17 +2219,26 @@ const SNAPSHOT_TRIGGER_SCRIPT: &str = r#"
 })();
 "#;
 
-/// JavaScript snippet injected via `eval()` during logout.  Clears all
-/// accessible cookies (with proper subdomain handling), localStorage,
-/// sessionStorage, then navigates to `https://www.messenger.com`.
+/// JavaScript snippet injected via `eval()` during logout.  Performs a
+/// best-effort client-side clear of JS-accessible cookies (including
+/// subdomain and path variants), localStorage, and sessionStorage, then
+/// navigates to `https://www.messenger.com`.
+///
+/// **Limitations** — This cannot remove `HttpOnly` cookies (commonly used
+/// for auth tokens) and only affects cookies for the *current* origin.
+/// A full session drop may require a server-side logout flow in addition
+/// to this client-side clear.
 ///
 /// * Cookie names are trimmed after splitting on `;`.
 /// * Empty cookie names are skipped (guards against `document.cookie === ''`).
 /// * Cookie expiry uses RFC1123 GMT format for cross-WebView compatibility.
 /// * The `while` loop stops before the TLD (`hostParts.length > 1`).
+/// * Path clearing includes the current pathname and all parent prefixes
+///   (e.g. `/messages/t/123`, `/messages/t`, `/messages`, `/`).
 /// * Any storage error is caught so the redirect always runs in `finally`.
 const LOGOUT_CLEAR_SCRIPT: &str = r#"
 try {
+    var pathSegments = window.location.pathname.split('/').filter(Boolean);
     document.cookie.split(';').forEach(function(c) {
         var eq = c.indexOf('=');
         var name = (eq > -1 ? c.substring(0, eq) : c).trim();
@@ -2237,11 +2246,19 @@ try {
         var hostParts = window.location.hostname.split('.');
         while (hostParts.length > 1) {
             var domain = hostParts.join('.');
-            document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/;domain=' + domain;
-            document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/;domain=.' + domain;
+            // Clear for root path and all parent path prefixes.
+            for (var i = pathSegments.length; i >= 0; i--) {
+                var p = '/' + pathSegments.slice(0, i).join('/');
+                document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=' + p + ';domain=' + domain;
+                document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=' + p + ';domain=.' + domain;
+            }
             hostParts.shift();
         }
-        document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/';
+        // Current origin (no domain attribute).
+        for (var i = pathSegments.length; i >= 0; i--) {
+            var p = '/' + pathSegments.slice(0, i).join('/');
+            document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=' + p;
+        }
     });
 } catch (e) {} finally {
     try { localStorage.clear(); } catch (e) {}
@@ -4473,9 +4490,10 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                         }
                         let _ = autostart_c.set_checked(false);
 
-                        // Clear WebView cookies / localStorage / sessionStorage
-                        // before navigating to messenger.com so Facebook's login
-                        // session is actually dropped.
+                        // Best-effort client-side clear of JS-accessible cookies
+                        // (including path variants), localStorage, and sessionStorage
+                        // before navigating to messenger.com.  HttpOnly cookies and
+                        // cookies for other origins are not affected by this script.
                         if let Some(wv) = handle.get_webview_window("main") {
                             let _ = wv.eval(LOGOUT_CLEAR_SCRIPT);
                             let _ = wv.show();
@@ -4963,8 +4981,10 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                     }
                     let _ = autostart_c.set_checked(false);
 
-                    // Clear WebView cookies / localStorage / sessionStorage
-                    // before navigating to messenger.com.
+                    // Best-effort client-side clear of JS-accessible cookies
+                    // (including path variants), localStorage, and sessionStorage
+                    // before navigating to messenger.com.  HttpOnly cookies and
+                    // cookies for other origins are not affected by this script.
                     if let Some(wv) = h.get_webview_window("main") {
                         let _ = wv.eval(LOGOUT_CLEAR_SCRIPT);
                         let _ = wv.show();
@@ -5463,6 +5483,21 @@ mod tests {
             assert!(
                 LOGOUT_CLEAR_SCRIPT.contains("if (!name) return"),
                 "logout script must skip empty cookie names"
+            );
+        }
+
+        /// The script must clear cookies for the current pathname and all
+        /// parent path prefixes (e.g. `/messages/t/123`, `/messages/t`,
+        /// `/messages`, `/`), not just `path=/`.
+        #[test]
+        fn clears_cookie_path_variants() {
+            assert!(
+                LOGOUT_CLEAR_SCRIPT.contains("pathSegments"),
+                "logout script must compute path segments"
+            );
+            assert!(
+                LOGOUT_CLEAR_SCRIPT.contains("window.location.pathname"),
+                "logout script must read current pathname"
             );
         }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4444,22 +4444,25 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                         // session is actually dropped.
                         if let Some(wv) = handle.get_webview_window("main") {
                             let _ = wv.eval(
-                                "document.cookie.split(';').forEach(function(c){\
-                                 var eq=c.indexOf('=');\
-                                 var name=(eq>-1?c.substr(0,eq):c).trim();\
-                                 var hostParts=window.location.hostname.split('.');\
-                                 while(hostParts.length>0){\
-                                  var domain=hostParts.join('.');\
-                                  document.cookie=name+'=;expires=Thu,01 Jan 1970 00:00:00 UTC;path=/;domain='+domain;\
-                                  document.cookie=name+'=;expires=Thu,01 Jan 1970 00:00:00 UTC;path=/;domain=.'+domain;\
-                                  hostParts.shift();\
-                                 }\
-                                 document.cookie=name+'=;expires=Thu,01 Jan 1970 00:00:00 UTC;path=/';\
-                                });\
-                                 localStorage.clear();\
-                                 sessionStorage.clear();\
-                                 sessionStorage.setItem('__mx_appearance','system');\
-                                 window.location.href='https://www.messenger.com';",
+                                "try{\
+                                 document.cookie.split(';').forEach(function(c){\
+                                  var eq=c.indexOf('=');\
+                                  var name=(eq>-1?c.substring(0,eq):c).trim();\
+                                  var hostParts=window.location.hostname.split('.');\
+                                  while(hostParts.length>1){\
+                                   var domain=hostParts.join('.');\
+                                   document.cookie=name+'=;expires=Thu,01 Jan 1970 00:00:00 UTC;path=/;domain='+domain;\
+                                   document.cookie=name+'=;expires=Thu,01 Jan 1970 00:00:00 UTC;path=/;domain=.'+domain;\
+                                   hostParts.shift();\
+                                  }\
+                                  document.cookie=name+'=;expires=Thu,01 Jan 1970 00:00:00 UTC;path=/';\
+                                 });\
+                                 }catch(e){}finally{\
+                                 try{localStorage.clear();}catch(e){}\
+                                 try{sessionStorage.clear();}catch(e){}\
+                                 try{sessionStorage.setItem('__mx_appearance','system');}catch(e){}\
+                                 window.location.href='https://www.messenger.com';\
+                                 }",
                             );
                             let _ = wv.show();
                             let _ = wv.set_focus();
@@ -4948,22 +4951,25 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                     // before navigating to messenger.com.
                     if let Some(wv) = h.get_webview_window("main") {
                         let _ = wv.eval(
-                            "document.cookie.split(';').forEach(function(c){\
-                             var eq=c.indexOf('=');\
-                             var name=(eq>-1?c.substr(0,eq):c).trim();\
-                             var hostParts=window.location.hostname.split('.');\
-                             while(hostParts.length>0){\
-                              var domain=hostParts.join('.');\
-                              document.cookie=name+'=;expires=Thu,01 Jan 1970 00:00:00 UTC;path=/;domain='+domain;\
-                              document.cookie=name+'=;expires=Thu,01 Jan 1970 00:00:00 UTC;path=/;domain=.'+domain;\
-                              hostParts.shift();\
-                             }\
-                             document.cookie=name+'=;expires=Thu,01 Jan 1970 00:00:00 UTC;path=/';\
-                            });\
-                             localStorage.clear();\
-                             sessionStorage.clear();\
-                             sessionStorage.setItem('__mx_appearance','system');\
-                             window.location.href='https://www.messenger.com';",
+                            "try{\
+                             document.cookie.split(';').forEach(function(c){\
+                              var eq=c.indexOf('=');\
+                              var name=(eq>-1?c.substring(0,eq):c).trim();\
+                              var hostParts=window.location.hostname.split('.');\
+                              while(hostParts.length>1){\
+                               var domain=hostParts.join('.');\
+                               document.cookie=name+'=;expires=Thu,01 Jan 1970 00:00:00 UTC;path=/;domain='+domain;\
+                               document.cookie=name+'=;expires=Thu,01 Jan 1970 00:00:00 UTC;path=/;domain=.'+domain;\
+                               hostParts.shift();\
+                              }\
+                              document.cookie=name+'=;expires=Thu,01 Jan 1970 00:00:00 UTC;path=/';\
+                             });\
+                             }catch(e){}finally{\
+                             try{localStorage.clear();}catch(e){}\
+                             try{sessionStorage.clear();}catch(e){}\
+                             try{sessionStorage.setItem('__mx_appearance','system');}catch(e){}\
+                             window.location.href='https://www.messenger.com';\
+                             }",
                         );
                         let _ = wv.show();
                         let _ = wv.set_focus();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2260,10 +2260,18 @@ try {
             document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=' + p;
         }
     });
-} catch (e) {} finally {
-    try { localStorage.clear(); } catch (e) {}
-    try { sessionStorage.clear(); } catch (e) {}
-    try { sessionStorage.setItem('__mx_appearance', 'system'); } catch (e) {}
+} catch (e) {
+    console.error('[MessengerX] Logout cookie clear failed:', e);
+} finally {
+    try { localStorage.clear(); } catch (e) {
+        console.error('[MessengerX] Logout localStorage clear failed:', e);
+    }
+    try { sessionStorage.clear(); } catch (e) {
+        console.error('[MessengerX] Logout sessionStorage clear failed:', e);
+    }
+    try { sessionStorage.setItem('__mx_appearance', 'system'); } catch (e) {
+        console.error('[MessengerX] Logout appearance reset failed:', e);
+    }
     window.location.href = 'https://www.messenger.com';
 }
 "#;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5556,38 +5556,4 @@ mod tests {
         }
     }
 
-    // -----------------------------------------------------------------------
-    // Logout handler regression tests — assert both platforms keep
-    // snapshot clearing + script evaluation in sync.
-    // -----------------------------------------------------------------------
-    mod logout_handlers {
-        const SOURCE: &str = include_str!("lib.rs");
-
-        /// Both logout handlers must call `services::cache::clear_snapshots`.
-        #[test]
-        fn both_logout_handlers_clear_snapshots() {
-            assert!(
-                SOURCE.contains("services::cache::clear_snapshots(handle)"),
-                "tray logout must clear snapshots"
-            );
-            assert!(
-                SOURCE.contains("services::cache::clear_snapshots(&h)"),
-                "macOS logout must clear snapshots"
-            );
-        }
-
-        /// Both logout handlers must evaluate `LOGOUT_CLEAR_SCRIPT` and
-        /// log errors instead of silently dropping them.
-        #[test]
-        fn both_logout_handlers_log_eval_errors() {
-            assert!(
-                SOURCE.contains("Failed to eval logout clear script"),
-                "logout handlers must log eval errors"
-            );
-            assert!(
-                SOURCE.contains("if let Err(e) = wv.eval(LOGOUT_CLEAR_SCRIPT)"),
-                "logout handlers must handle eval Result"
-            );
-        }
-    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2247,11 +2247,18 @@ const LOGOUT_CLEAR_SCRIPT: &str = r#"
             var hostParts = window.location.hostname.split('.');
             while (hostParts.length > 1) {
                 var domain = hostParts.join('.');
-                // Clear for root path and all parent path prefixes.
+                // Clear for root path and all parent path prefixes
+                // (both with and without trailing slash, since they are
+                // distinct cookie identities).
                 for (var i = pathSegments.length; i >= 0; i--) {
                     var p = '/' + pathSegments.slice(0, i).join('/');
                     document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=' + p + ';domain=' + domain;
                     document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=' + p + ';domain=.' + domain;
+                    if (i > 0) {
+                        var pSlash = p + '/';
+                        document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=' + pSlash + ';domain=' + domain;
+                        document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=' + pSlash + ';domain=.' + domain;
+                    }
                 }
                 hostParts.shift();
             }
@@ -2259,6 +2266,9 @@ const LOGOUT_CLEAR_SCRIPT: &str = r#"
             for (var i = pathSegments.length; i >= 0; i--) {
                 var p = '/' + pathSegments.slice(0, i).join('/');
                 document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=' + p;
+                if (i > 0) {
+                    document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=' + p + '/';
+                }
             }
         });
     } catch (e) {
@@ -5502,7 +5512,9 @@ mod tests {
 
         /// The script must clear cookies for the current pathname and all
         /// parent path prefixes (e.g. `/messages/t/123`, `/messages/t`,
-        /// `/messages`, `/`), not just `path=/`.
+        /// `/messages`, `/`), not just `path=/`.  It must also try the
+        /// trailing-slash variant of each prefix (e.g. `/messages/` is a
+        /// distinct cookie identity from `/messages`).
         #[test]
         fn clears_cookie_path_variants() {
             assert!(
@@ -5512,6 +5524,10 @@ mod tests {
             assert!(
                 LOGOUT_CLEAR_SCRIPT.contains("window.location.pathname"),
                 "logout script must read current pathname"
+            );
+            assert!(
+                LOGOUT_CLEAR_SCRIPT.contains("var pSlash = p + '/'"),
+                "logout script must clear trailing-slash path variants"
             );
         }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5255,28 +5255,6 @@ mod tests {
         }
     }
 
-    mod logout_handlers {
-        const SOURCE: &str = include_str!("lib.rs");
-
-        #[test]
-        fn both_logout_handlers_clear_snapshots() {
-            assert!(
-                SOURCE.contains("services::cache::clear_snapshots(handle)")
-                    && SOURCE.contains("services::cache::clear_snapshots(&h)"),
-                "both tray and macOS logout handlers must clear snapshots"
-            );
-        }
-
-        #[test]
-        fn both_logout_handlers_use_shared_logout_script() {
-            assert_eq!(
-                SOURCE.matches("wv.eval(LOGOUT_CLEAR_SCRIPT)").count(),
-                2,
-                "both tray and macOS logout handlers must eval LOGOUT_CLEAR_SCRIPT"
-            );
-        }
-    }
-
     #[cfg(target_os = "linux")]
     mod linux_runtime {
         use super::super::{configure_linux_runtime_env, LINUX_APPIMAGE_ENV_OVERRIDES};
@@ -5565,28 +5543,32 @@ mod tests {
     mod logout_handlers {
         const SOURCE: &str = include_str!("lib.rs");
 
-        /// The tray (Windows/Linux) logout handler must call
-        /// `services::cache::clear_snapshots` and evaluate `LOGOUT_CLEAR_SCRIPT`.
+        /// Both logout handlers must call `services::cache::clear_snapshots`.
         #[test]
-        fn tray_logout_clears_snapshots_and_evals_script() {
+        fn both_logout_handlers_clear_snapshots() {
             assert!(
                 SOURCE.contains("services::cache::clear_snapshots(handle)"),
                 "tray logout must clear snapshots"
             );
+            assert!(
+                SOURCE.contains("services::cache::clear_snapshots(&h)"),
+                "macOS logout must clear snapshots"
+            );
+        }
+
+        /// The tray (Windows/Linux) logout handler must evaluate
+        /// `LOGOUT_CLEAR_SCRIPT`.
+        #[test]
+        fn tray_logout_evals_script() {
             assert!(
                 SOURCE.contains("let _ = wv.eval(LOGOUT_CLEAR_SCRIPT);"),
                 "tray logout must eval LOGOUT_CLEAR_SCRIPT"
             );
         }
 
-        /// The macOS menu logout handler must call
-        /// `services::cache::clear_snapshots(&h)` and evaluate `LOGOUT_CLEAR_SCRIPT`.
+        /// The macOS menu logout handler must evaluate `LOGOUT_CLEAR_SCRIPT`.
         #[test]
-        fn macos_logout_clears_snapshots_and_evals_script() {
-            assert!(
-                SOURCE.contains("services::cache::clear_snapshots(&h)"),
-                "macOS logout must clear snapshots"
-            );
+        fn macos_logout_evals_script() {
             assert!(
                 SOURCE.contains("let _ = wv.eval(LOGOUT_CLEAR_SCRIPT);"),
                 "macOS logout must eval LOGOUT_CLEAR_SCRIPT"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4505,7 +4505,9 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                         // before navigating to messenger.com.  HttpOnly cookies and
                         // cookies for other origins are not affected by this script.
                         if let Some(wv) = handle.get_webview_window("main") {
-                            let _ = wv.eval(LOGOUT_CLEAR_SCRIPT);
+                            if let Err(e) = wv.eval(LOGOUT_CLEAR_SCRIPT) {
+                                log::warn!("[MessengerX] Failed to eval logout clear script: {e}");
+                            }
                             let _ = wv.show();
                             let _ = wv.set_focus();
                         }
@@ -4996,7 +4998,9 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                     // before navigating to messenger.com.  HttpOnly cookies and
                     // cookies for other origins are not affected by this script.
                     if let Some(wv) = h.get_webview_window("main") {
-                        let _ = wv.eval(LOGOUT_CLEAR_SCRIPT);
+                        if let Err(e) = wv.eval(LOGOUT_CLEAR_SCRIPT) {
+                            log::warn!("[MessengerX] Failed to eval logout clear script: {e}");
+                        }
                         let _ = wv.show();
                         let _ = wv.set_focus();
                     }
@@ -5556,22 +5560,17 @@ mod tests {
             );
         }
 
-        /// The tray (Windows/Linux) logout handler must evaluate
-        /// `LOGOUT_CLEAR_SCRIPT`.
+        /// Both logout handlers must evaluate `LOGOUT_CLEAR_SCRIPT` and
+        /// log errors instead of silently dropping them.
         #[test]
-        fn tray_logout_evals_script() {
+        fn both_logout_handlers_log_eval_errors() {
             assert!(
-                SOURCE.contains("let _ = wv.eval(LOGOUT_CLEAR_SCRIPT);"),
-                "tray logout must eval LOGOUT_CLEAR_SCRIPT"
+                SOURCE.contains("Failed to eval logout clear script"),
+                "logout handlers must log eval errors"
             );
-        }
-
-        /// The macOS menu logout handler must evaluate `LOGOUT_CLEAR_SCRIPT`.
-        #[test]
-        fn macos_logout_evals_script() {
             assert!(
-                SOURCE.contains("let _ = wv.eval(LOGOUT_CLEAR_SCRIPT);"),
-                "macOS logout must eval LOGOUT_CLEAR_SCRIPT"
+                SOURCE.contains("if let Err(e) = wv.eval(LOGOUT_CLEAR_SCRIPT)"),
+                "logout handlers must handle eval Result"
             );
         }
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4404,6 +4404,7 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
 
                     // ---- Log out & clear data ----
                     "logout" => {
+                        let _ = services::cache::clear_snapshots(handle);
                         let defaults = crate::commands::AppSettings::default();
                         let _ = services::auth::save_settings(handle, &defaults);
 
@@ -4438,12 +4439,26 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                         }
                         let _ = autostart_c.set_checked(false);
 
-                        // Navigate to messenger.com to clear session/cookies.
-                        // Also reset the appearance sessionStorage key so the
-                        // init-script starts clean on the new page load.
+                        // Clear WebView cookies / localStorage / sessionStorage
+                        // before navigating to messenger.com so Facebook's login
+                        // session is actually dropped.
                         if let Some(wv) = handle.get_webview_window("main") {
                             let _ = wv.eval(
-                                "sessionStorage.setItem('__mx_appearance','system');\
+                                "document.cookie.split(';').forEach(function(c){\
+                                 var eq=c.indexOf('=');\
+                                 var name=(eq>-1?c.substr(0,eq):c).trim();\
+                                 var hostParts=window.location.hostname.split('.');\
+                                 while(hostParts.length>0){\
+                                  var domain=hostParts.join('.');\
+                                  document.cookie=name+'=;expires=Thu,01 Jan 1970 00:00:00 UTC;path=/;domain='+domain;\
+                                  document.cookie=name+'=;expires=Thu,01 Jan 1970 00:00:00 UTC;path=/;domain=.'+domain;\
+                                  hostParts.shift();\
+                                 }\
+                                 document.cookie=name+'=;expires=Thu,01 Jan 1970 00:00:00 UTC;path=/';\
+                                });\
+                                 localStorage.clear();\
+                                 sessionStorage.clear();\
+                                 sessionStorage.setItem('__mx_appearance','system');\
                                  window.location.href='https://www.messenger.com';",
                             );
                             let _ = wv.show();
@@ -4929,12 +4944,25 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                     }
                     let _ = autostart_c.set_checked(false);
 
-                    // Navigate to messenger.com to clear session/cookies.
-                    // Also reset the appearance sessionStorage key so the
-                    // init-script starts clean on the new page load.
+                    // Clear WebView cookies / localStorage / sessionStorage
+                    // before navigating to messenger.com.
                     if let Some(wv) = h.get_webview_window("main") {
                         let _ = wv.eval(
-                            "sessionStorage.setItem('__mx_appearance','system');\
+                            "document.cookie.split(';').forEach(function(c){\
+                             var eq=c.indexOf('=');\
+                             var name=(eq>-1?c.substr(0,eq):c).trim();\
+                             var hostParts=window.location.hostname.split('.');\
+                             while(hostParts.length>0){\
+                              var domain=hostParts.join('.');\
+                              document.cookie=name+'=;expires=Thu,01 Jan 1970 00:00:00 UTC;path=/;domain='+domain;\
+                              document.cookie=name+'=;expires=Thu,01 Jan 1970 00:00:00 UTC;path=/;domain=.'+domain;\
+                              hostParts.shift();\
+                             }\
+                             document.cookie=name+'=;expires=Thu,01 Jan 1970 00:00:00 UTC;path=/';\
+                            });\
+                             localStorage.clear();\
+                             sessionStorage.clear();\
+                             sessionStorage.setItem('__mx_appearance','system');\
                              window.location.href='https://www.messenger.com';",
                         );
                         let _ = wv.show();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2237,43 +2237,45 @@ const SNAPSHOT_TRIGGER_SCRIPT: &str = r#"
 ///   (e.g. `/messages/t/123`, `/messages/t`, `/messages`, `/`).
 /// * Any storage error is caught so the redirect always runs in `finally`.
 const LOGOUT_CLEAR_SCRIPT: &str = r#"
-try {
-    var pathSegments = window.location.pathname.split('/').filter(Boolean);
-    document.cookie.split(';').forEach(function(c) {
-        var eq = c.indexOf('=');
-        var name = (eq > -1 ? c.substring(0, eq) : c).trim();
-        if (!name) return;
-        var hostParts = window.location.hostname.split('.');
-        while (hostParts.length > 1) {
-            var domain = hostParts.join('.');
-            // Clear for root path and all parent path prefixes.
+(function() {
+    try {
+        var pathSegments = window.location.pathname.split('/').filter(Boolean);
+        document.cookie.split(';').forEach(function(c) {
+            var eq = c.indexOf('=');
+            var name = (eq > -1 ? c.substring(0, eq) : c).trim();
+            if (!name) return;
+            var hostParts = window.location.hostname.split('.');
+            while (hostParts.length > 1) {
+                var domain = hostParts.join('.');
+                // Clear for root path and all parent path prefixes.
+                for (var i = pathSegments.length; i >= 0; i--) {
+                    var p = '/' + pathSegments.slice(0, i).join('/');
+                    document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=' + p + ';domain=' + domain;
+                    document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=' + p + ';domain=.' + domain;
+                }
+                hostParts.shift();
+            }
+            // Current origin (no domain attribute).
             for (var i = pathSegments.length; i >= 0; i--) {
                 var p = '/' + pathSegments.slice(0, i).join('/');
-                document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=' + p + ';domain=' + domain;
-                document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=' + p + ';domain=.' + domain;
+                document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=' + p;
             }
-            hostParts.shift();
+        });
+    } catch (e) {
+        console.error('[MessengerX] Logout cookie clear failed:', e);
+    } finally {
+        try { localStorage.clear(); } catch (e) {
+            console.error('[MessengerX] Logout localStorage clear failed:', e);
         }
-        // Current origin (no domain attribute).
-        for (var i = pathSegments.length; i >= 0; i--) {
-            var p = '/' + pathSegments.slice(0, i).join('/');
-            document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=' + p;
+        try { sessionStorage.clear(); } catch (e) {
+            console.error('[MessengerX] Logout sessionStorage clear failed:', e);
         }
-    });
-} catch (e) {
-    console.error('[MessengerX] Logout cookie clear failed:', e);
-} finally {
-    try { localStorage.clear(); } catch (e) {
-        console.error('[MessengerX] Logout localStorage clear failed:', e);
+        try { sessionStorage.setItem('__mx_appearance', 'system'); } catch (e) {
+            console.error('[MessengerX] Logout appearance reset failed:', e);
+        }
+        window.location.href = 'https://www.messenger.com';
     }
-    try { sessionStorage.clear(); } catch (e) {
-        console.error('[MessengerX] Logout sessionStorage clear failed:', e);
-    }
-    try { sessionStorage.setItem('__mx_appearance', 'system'); } catch (e) {
-        console.error('[MessengerX] Logout appearance reset failed:', e);
-    }
-    window.location.href = 'https://www.messenger.com';
-}
+})();
 "#;
 
 // ---------------------------------------------------------------------------
@@ -5538,6 +5540,56 @@ mod tests {
             assert!(
                 LOGOUT_CLEAR_SCRIPT.contains("hostParts.length > 1"),
                 "cookie loop must stop before TLD"
+            );
+        }
+
+        /// The script must be wrapped in an IIFE so that `var` bindings
+        /// do not leak onto the global `window` object.
+        #[test]
+        fn wrapped_in_iife() {
+            assert!(
+                LOGOUT_CLEAR_SCRIPT.trim_start().starts_with("(function()"),
+                "logout script must be wrapped in an IIFE"
+            );
+            assert!(
+                LOGOUT_CLEAR_SCRIPT.trim_end().ends_with(")();"),
+                "logout script IIFE must end with )();"
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Logout handler regression tests — assert both platforms keep
+    // snapshot clearing + script evaluation in sync.
+    // -----------------------------------------------------------------------
+    mod logout_handlers {
+        const SOURCE: &str = include_str!("lib.rs");
+
+        /// The tray (Windows/Linux) logout handler must call
+        /// `services::cache::clear_snapshots` and evaluate `LOGOUT_CLEAR_SCRIPT`.
+        #[test]
+        fn tray_logout_clears_snapshots_and_evals_script() {
+            assert!(
+                SOURCE.contains("services::cache::clear_snapshots(handle)"),
+                "tray logout must clear snapshots"
+            );
+            assert!(
+                SOURCE.contains("let _ = wv.eval(LOGOUT_CLEAR_SCRIPT);"),
+                "tray logout must eval LOGOUT_CLEAR_SCRIPT"
+            );
+        }
+
+        /// The macOS menu logout handler must call
+        /// `services::cache::clear_snapshots(&h)` and evaluate `LOGOUT_CLEAR_SCRIPT`.
+        #[test]
+        fn macos_logout_clears_snapshots_and_evals_script() {
+            assert!(
+                SOURCE.contains("services::cache::clear_snapshots(&h)"),
+                "macOS logout must clear snapshots"
+            );
+            assert!(
+                SOURCE.contains("let _ = wv.eval(LOGOUT_CLEAR_SCRIPT);"),
+                "macOS logout must eval LOGOUT_CLEAR_SCRIPT"
             );
         }
     }

--- a/src-tauri/tests/logout_handlers.rs
+++ b/src-tauri/tests/logout_handlers.rs
@@ -1,0 +1,36 @@
+//! Integration test: assert both logout handlers (tray / macOS menu) keep
+//! snapshot clearing and LOGOUT_CLEAR_SCRIPT evaluation in sync.
+//!
+//! These checks live in an integration test (not unit tests inside lib.rs)
+//! so that `include_str!("../src/lib.rs")` does NOT include the assertions
+//! themselves — preventing false positives where the test passes because
+//! the searched string appears inside the test code.
+
+const SOURCE: &str = include_str!("../src/lib.rs");
+
+/// Both logout handlers must call `services::cache::clear_snapshots`.
+#[test]
+fn both_logout_handlers_clear_snapshots() {
+    assert!(
+        SOURCE.contains("services::cache::clear_snapshots(handle)"),
+        "tray logout must clear snapshots"
+    );
+    assert!(
+        SOURCE.contains("services::cache::clear_snapshots(&h)"),
+        "macOS logout must clear snapshots"
+    );
+}
+
+/// Both logout handlers must evaluate `LOGOUT_CLEAR_SCRIPT` and
+/// log errors instead of silently dropping them.
+#[test]
+fn both_logout_handlers_log_eval_errors() {
+    assert!(
+        SOURCE.contains("Failed to eval logout clear script"),
+        "logout handlers must log eval errors"
+    );
+    assert!(
+        SOURCE.contains("if let Err(e) = wv.eval(LOGOUT_CLEAR_SCRIPT)"),
+        "logout handlers must handle eval Result"
+    );
+}


### PR DESCRIPTION
**macOS:** The logout handler already called ; this PR improves the cookie/storage clearing script to handle path-specific cookies and clarifies its limitations.\n\n**Windows/Linux:** Adds the missing  call to the tray logout handler and shares the same improved clearing script.\n\n**Changes:**\n- Extract duplicated logout JS into shared  constant (tray + macOS menu handlers).\n- Clear cookies for the current pathname and all parent path prefixes, not just .\n- Empty cookie name guard () prevents invalid assignments when .\n- Cookie expiry uses RFC1123  with spaces for cross-WebView compatibility.\n- Loop stops before TLD ().\n-  errors logged instead of silently dropped.\n- Comments reworded as 'best-effort client-side clear' — acknowledges HttpOnly cookies and other-origin cookies are not affected.\n- 8 unit tests asserting cookie clearing, storage clearing, appearance reset, messenger.com redirect, GMT format, empty-name guard, TLD stop, and path variants.