### PR TITLE
fix: CrashDetect false-positive on startup (splash title arms had_good_title)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2977,6 +2977,13 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     // ------------------------------------------------------------------
     let had_good_title = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let crash_reload_count = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+    // Set to `true` by `on_navigation` the first time the webview commits to a
+    // `www.messenger.com` URL.  `had_good_title` must NOT be set from the
+    // `loading.html` splash page title ("Messenger X") — that would cause a
+    // false-positive CrashDetect when the page title briefly clears during the
+    // initial SPA navigation on macOS WKWebView.
+    let messenger_com_navigated =
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     // ------------------------------------------------------------------
     // Sender-hint cache.
     //
@@ -3149,6 +3156,7 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
             let crash_reload_count = crash_reload_count.clone();
             let pending_sender_hint = pending_sender_hint.clone();
             let post_crash_proxy_block = post_crash_proxy_block.clone();
+            let messenger_com_navigated = messenger_com_navigated.clone();
             move |webview_window, title| {
                 const SENDER_HINT_PREFIX: &str = "__MX_SENDER_V1__?";
                 if let Some(query) = title.strip_prefix(SENDER_HINT_PREFIX) {
@@ -3330,7 +3338,17 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                 // Guard: had_good_title is reset before each reload so that
                 // a series of back-to-back crashes doesn't bypass the count.
                 // ---------------------------------------------------------
-                if title.contains("Messenger") && !title.trim().is_empty() {
+                // Only count a title as "good" when we have already committed
+                // to a real messenger.com URL.  The loading.html splash page
+                // title ("Messenger X") also contains "Messenger", so without
+                // this guard it would arm the crash detector — causing a false-
+                // positive CrashDetect when the title briefly clears during the
+                // initial SPA navigation on macOS WKWebView.
+                if title.contains("Messenger")
+                    && !title.trim().is_empty()
+                    && messenger_com_navigated
+                        .load(std::sync::atomic::Ordering::Relaxed)
+                {
                     had_good_title.store(true, std::sync::atomic::Ordering::Relaxed);
                 }
 
@@ -3426,6 +3444,7 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         // open everything else in the system browser.
         .on_navigation({
             let post_crash_proxy_block = post_crash_proxy_block.clone();
+            let messenger_com_navigated_nav = messenger_com_navigated.clone();
             move |url| {
                 let scheme = url.scheme();
                 // Pass through non-HTTP schemes (blob:, data:, about:, tauri:, etc.).
@@ -3446,6 +3465,15 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                     "[MessengerX] on_navigation: host={host} url={url} t={}ms",
                     setup_started.elapsed().as_millis()
                 );
+
+                // Arm crash detection once we have committed to a real
+                // messenger.com URL.  This prevents the loading.html splash
+                // title ("Messenger X") from falsely arming `had_good_title`
+                // before the SPA has actually loaded.
+                if host == "www.messenger.com" {
+                    messenger_com_navigated_nav
+                        .store(true, std::sync::atomic::Ordering::Relaxed);
+                }
 
                 // Post-crash fbsbx proxy block (Linux only).
                 //

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2977,11 +2977,14 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     // ------------------------------------------------------------------
     let had_good_title = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let crash_reload_count = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
-    // Set to `true` by `on_navigation` the first time the webview commits to a
-    // `www.messenger.com` URL.  `had_good_title` must NOT be set from the
-    // `loading.html` splash page title ("Messenger X") — that would cause a
-    // false-positive CrashDetect when the page title briefly clears during the
-    // initial SPA navigation on macOS WKWebView.
+    // Set to `true` by `on_navigation` the first time a navigation to a
+    // `www.messenger.com` URL is allowed through the policy callback.
+    // (`on_navigation` is a policy hook that may also return `false` to
+    // cancel; it is NOT a navigation-committed signal.)
+    // `had_good_title` must NOT be set from the `loading.html` splash page
+    // title ("Messenger X") — that would cause a false-positive CrashDetect
+    // when the page title briefly clears during the initial SPA navigation on
+    // macOS WKWebView.
     let messenger_com_navigated =
         std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     // ------------------------------------------------------------------
@@ -3338,8 +3341,8 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                 // Guard: had_good_title is reset before each reload so that
                 // a series of back-to-back crashes doesn't bypass the count.
                 // ---------------------------------------------------------
-                // Only count a title as "good" when we have already committed
-                // to a real messenger.com URL.  The loading.html splash page
+                // Only count a title as "good" once a real messenger.com
+                // navigation has been allowed.  The loading.html splash page
                 // title ("Messenger X") also contains "Messenger", so without
                 // this guard it would arm the crash detector — causing a false-
                 // positive CrashDetect when the title briefly clears during the
@@ -3466,10 +3469,10 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                     setup_started.elapsed().as_millis()
                 );
 
-                // Arm crash detection once we have committed to a real
-                // messenger.com URL.  This prevents the loading.html splash
-                // title ("Messenger X") from falsely arming `had_good_title`
-                // before the SPA has actually loaded.
+                // Arm crash detection once a www.messenger.com navigation has
+                // been allowed by the policy callback.  This prevents the
+                // loading.html splash title ("Messenger X") from falsely
+                // arming `had_good_title` before the SPA has actually loaded.
                 if host == "www.messenger.com" {
                     messenger_com_navigated_nav
                         .store(true, std::sync::atomic::Ordering::Relaxed);

--- a/src-tauri/tests/crash_detect.rs
+++ b/src-tauri/tests/crash_detect.rs
@@ -1,0 +1,38 @@
+//! Regression tests: assert that the CrashDetect `had_good_title` arming guard
+//! (`messenger_com_navigated`) remains in place so that the `loading.html`
+//! splash-page title cannot trigger a false-positive crash-detection loop.
+//!
+//! These live in an integration-test file (not inside lib.rs) so that
+//! `include_str!("../src/lib.rs")` does NOT include the assertions themselves —
+//! preventing false positives where the searched string appears inside the test.
+
+const SOURCE: &str = include_str!("../src/lib.rs");
+
+/// `had_good_title` must only be set when `messenger_com_navigated` is also
+/// true.  Without this guard the loading.html title "Messenger X" (which
+/// contains "Messenger") would arm the crash detector before any real
+/// messenger.com page has loaded, causing a false-positive auto-reload on
+/// every cold launch.
+#[test]
+fn had_good_title_is_gated_on_messenger_com_navigated() {
+    assert!(
+        SOURCE.contains("&& messenger_com_navigated"),
+        "had_good_title arming must be guarded by && messenger_com_navigated"
+    );
+}
+
+/// The `on_navigation` handler must set the `messenger_com_navigated` flag
+/// when it allows a navigation to `www.messenger.com`.  If this setter is
+/// removed the guard in `on_document_title_changed` will never arm and the
+/// crash detector will never fire — even for real crashes.
+#[test]
+fn on_navigation_sets_messenger_com_navigated_for_messenger_host() {
+    assert!(
+        SOURCE.contains("if host == \"www.messenger.com\" {"),
+        "on_navigation must have a www.messenger.com host check"
+    );
+    assert!(
+        SOURCE.contains("messenger_com_navigated_nav"),
+        "on_navigation must reference messenger_com_navigated_nav to set the flag"
+    );
+}


### PR DESCRIPTION
## Problem

On every cold launch with a saved thread URL, the app triggered a spurious `CrashDetect` warning and scheduled an unnecessary auto-reload, sometimes producing a visible start loop.

**Log evidence:**
```
[TitleChange] title="Messenger X"   ← loading.html splash arms had_good_title
[TitleChange] title=""              ← normal WKWebView SPA transition
[CrashDetect] WebKitWebProcess crash suspected … Scheduling auto-reload 1/3.  ← false positive
```

**Root cause:** `loading.html` has title `"Messenger X"` which satisfies `title.contains("Messenger")` → `had_good_title` was set `true` before any real messenger.com page loaded. macOS WKWebView normally emits `""` briefly while a new document is loading (not a crash), but the old check saw `had_good_title == true` + empty title and fired.

## Fix

Introduce a `messenger_com_navigated: Arc<AtomicBool>` (initially `false`):

| Where | Change |
|---|---|
| `on_navigation` | Set `true` when `host == "www.messenger.com"` is committed (`tauri://` URLs early-return before this point, so the splash page can never set it) |
| `on_document_title_changed` | `had_good_title = true` is now gated on `messenger_com_navigated == true` |

Real crashes after a successful load are still caught correctly — `on_navigation` commits well before the SPA renders a good title, so the detector arms as normal once Messenger loads.

## Checks
- `cargo clippy` ✅
- `tsc --noEmit` ✅