### PR TITLE
fix: CrashDetect SPA navigation false-positive loop (macOS) + cross-platform else-branch reset

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4279,7 +4279,6 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         let appearance_light_c = appearance_light_item.clone();
 
         // Translated strings for update-check notifications.
-        let tr_update_available = tr.settings_update_available.clone();
         let tr_no_update = tr.settings_no_update.clone();
         let tr_update_error = tr.settings_update_error.clone();
         let tr_update_ready = tr.settings_update_ready.clone();
@@ -4444,7 +4443,6 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                     // ---- Check for updates ----
                     "check_update" => {
                         let h = handle.clone();
-                        let tr_avail = tr_update_available.clone();
                         let tr_none = tr_no_update.clone();
                         let tr_err = tr_update_error.clone();
                         let tr_ready = tr_update_ready.clone();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2987,6 +2987,20 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     // macOS WKWebView.
     let messenger_com_navigated =
         std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    // On macOS WKWebView the document title briefly becomes `""` during
+    // EVERY SPA navigation (not only after a real WebKit crash).  To avoid
+    // false-positive CrashDetect fires we track whether the page has
+    // finished loading:
+    //   • Reset to `false` in `on_navigation` for www.messenger.com
+    //     (navigation has started, page is not yet stable).
+    //   • Set to `true` in `on_page_load::Finished` for www.messenger.com
+    //     (DOMContentLoaded-equivalent; page is now stable).
+    // `had_good_title` may only be set on macOS when `page_load_stable`
+    // is `true`, and CrashDetect may only fire on macOS when it is `true`.
+    // On Linux/Windows the old behaviour is preserved (WebKitGTK /
+    // WebView2 do NOT emit `""` title during normal SPA navigation).
+    let page_load_stable =
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     // ------------------------------------------------------------------
     // Sender-hint cache.
     //
@@ -3160,6 +3174,7 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
             let pending_sender_hint = pending_sender_hint.clone();
             let post_crash_proxy_block = post_crash_proxy_block.clone();
             let messenger_com_navigated = messenger_com_navigated.clone();
+            let page_load_stable = page_load_stable.clone();
             move |webview_window, title| {
                 const SENDER_HINT_PREFIX: &str = "__MX_SENDER_V1__?";
                 if let Some(query) = title.strip_prefix(SENDER_HINT_PREFIX) {
@@ -3340,6 +3355,18 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                 //
                 // Guard: had_good_title is reset before each reload so that
                 // a series of back-to-back crashes doesn't bypass the count.
+                //
+                // macOS vs Linux/Windows:
+                //   • macOS WKWebView emits title="" during EVERY SPA
+                //     navigation (not only on crash) → page_load_stable
+                //     gate prevents false-positive CrashDetect fires during
+                //     normal thread navigation.
+                //   • Linux WebKitGTK / Windows WebView2 do NOT clear the
+                //     title during clean SPA navigation — title="" appears
+                //     only on a real WebKitWebProcess crash → the
+                //     page_load_stable gate short-circuits to `true` there
+                //     (!cfg!(target_os = "macos") == true) so crash
+                //     detection is unchanged on Linux/Windows.
                 // ---------------------------------------------------------
                 // Only count a title as "good" once a real messenger.com
                 // navigation has been allowed.  The loading.html splash page
@@ -3347,17 +3374,30 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                 // this guard it would arm the crash detector — causing a false-
                 // positive CrashDetect when the title briefly clears during the
                 // initial SPA navigation on macOS WKWebView.
+                //
+                // On macOS we additionally require `page_load_stable == true`
+                // (set by on_page_load::Finished) because WKWebView emits
+                // title="" during EVERY SPA navigation, not only after a crash.
+                // On Linux/Windows this extra guard is skipped — WebKitGTK and
+                // WebView2 only emit title="" after real crashes.
                 if title.contains("Messenger")
                     && !title.trim().is_empty()
                     && messenger_com_navigated
                         .load(std::sync::atomic::Ordering::Relaxed)
+                    && (!cfg!(target_os = "macos")
+                        || page_load_stable.load(std::sync::atomic::Ordering::Relaxed))
                 {
                     had_good_title.store(true, std::sync::atomic::Ordering::Relaxed);
                 }
 
                 const MAX_CRASH_RELOADS: u32 = 3;
+                // On macOS also require page_load_stable so we don't fire
+                // during normal SPA navigation (WKWebView clears the title on
+                // every navigation, not just on crash).
                 if title.trim().is_empty()
                     && had_good_title.load(std::sync::atomic::Ordering::Relaxed)
+                    && (!cfg!(target_os = "macos")
+                        || page_load_stable.load(std::sync::atomic::Ordering::Relaxed))
                 {
                     let prev_count =
                         crash_reload_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -3391,9 +3431,17 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                             }
                         });
                     } else {
+                        // Reset had_good_title (all platforms) so that
+                        // subsequent empty-title events — whether from a
+                        // real crash before the recovery page sets its
+                        // title (Linux: GStreamer crash mid-load) or from
+                        // a macOS SPA navigation — do not immediately
+                        // re-trigger this else branch, creating an
+                        // infinite navigate-to-root loop.
+                        had_good_title.store(false, std::sync::atomic::Ordering::Relaxed);
                         log::warn!(
                             "[MessengerX][CrashDetect] Max crash reloads ({MAX_CRASH_RELOADS}) \
-                             reached — navigating to messenger.com root to restore usability."
+                              reached — navigating to messenger.com root to restore usability."
                         );
                         // Navigate to root so the user is not left with a
                         // blank / crashed window.  We do not increment the
@@ -3430,24 +3478,49 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         // (DOMContentLoaded equivalent) with milliseconds since app launch.
         // This lets us pinpoint which phase accounts for the 27-second white-
         // screen gap observed on Win11 (WebView2 boot timing diagnostic).
+        //
+        // On macOS, `Finished` for www.messenger.com additionally marks
+        // `page_load_stable = true` so the CrashDetect gate is re-armed
+        // only after the SPA has fully settled (WKWebView emits title=""
+        // during every SPA navigation; we must not treat that as a crash).
         // ------------------------------------------------------------------
-        .on_page_load(move |_webview_window, payload| {
-            use tauri::webview::PageLoadEvent;
-            let event_str = match payload.event() {
-                PageLoadEvent::Started => "Started",
-                PageLoadEvent::Finished => "Finished",
-            };
-            log::info!(
-                "[MessengerX][PageLoad] event={event_str} url={} t={}ms",
-                payload.url(),
-                setup_started.elapsed().as_millis(),
-            );
+        .on_page_load({
+            let page_load_stable_pl = page_load_stable.clone();
+            move |_webview_window, payload| {
+                use tauri::webview::PageLoadEvent;
+                let event_str = match payload.event() {
+                    PageLoadEvent::Started => "Started",
+                    PageLoadEvent::Finished => "Finished",
+                };
+                log::info!(
+                    "[MessengerX][PageLoad] event={event_str} url={} t={}ms",
+                    payload.url(),
+                    setup_started.elapsed().as_millis(),
+                );
+                // macOS only: re-arm the crash-detect stable flag once the
+                // page has finished loading for messenger.com.  Using
+                // `cfg!(target_os = "macos")` (a runtime bool) rather than
+                // `#[cfg(...)]` keeps `page_load_stable_pl` referenced in
+                // the closure body on all platforms, avoiding an
+                // unused-variable warning on Linux/Windows.
+                if cfg!(target_os = "macos") && matches!(payload.event(), PageLoadEvent::Finished) {
+                    let host = payload.url().host_str().unwrap_or("");
+                    if host == "www.messenger.com" {
+                        page_load_stable_pl.store(true, std::sync::atomic::Ordering::Relaxed);
+                        log::info!(
+                            "[MessengerX][CrashDetect] page_load_stable=true (Finished, \
+                             www.messenger.com)"
+                        );
+                    }
+                }
+            }
         })
         // Navigation policy: allow Messenger / Facebook CDN domains;
         // open everything else in the system browser.
         .on_navigation({
             let post_crash_proxy_block = post_crash_proxy_block.clone();
             let messenger_com_navigated_nav = messenger_com_navigated.clone();
+            let page_load_stable_nav = page_load_stable.clone();
             move |url| {
                 let scheme = url.scheme();
                 // Pass through non-HTTP schemes (blob:, data:, about:, tauri:, etc.).
@@ -3476,6 +3549,12 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                 if host == "www.messenger.com" {
                     messenger_com_navigated_nav
                         .store(true, std::sync::atomic::Ordering::Relaxed);
+                    // On macOS, mark the page as not yet stable so the
+                    // empty-title SPA transition doesn't trigger CrashDetect.
+                    // Stability is restored by on_page_load::Finished.
+                    if cfg!(target_os = "macos") {
+                        page_load_stable_nav.store(false, std::sync::atomic::Ordering::Relaxed);
+                    }
                 }
 
                 // Post-crash fbsbx proxy block (Linux only).

--- a/src-tauri/tests/crash_detect.rs
+++ b/src-tauri/tests/crash_detect.rs
@@ -1,5 +1,6 @@
 //! Regression tests: assert that the CrashDetect `had_good_title` arming guard
-//! (`messenger_com_navigated`) remains in place so that the `loading.html`
+//! (`messenger_com_navigated`) and the macOS `page_load_stable` SPA-navigation
+//! guard remain in place so that normal SPA title-clears and the `loading.html`
 //! splash-page title cannot trigger a false-positive crash-detection loop.
 //!
 //! These live in an integration-test file (not inside lib.rs) so that
@@ -7,6 +8,10 @@
 //! preventing false positives where the searched string appears inside the test.
 
 const SOURCE: &str = include_str!("../src/lib.rs");
+
+// ---------------------------------------------------------------------------
+// messenger_com_navigated guard (startup false-positive fix)
+// ---------------------------------------------------------------------------
 
 /// `had_good_title` must only be set when `messenger_com_navigated` is also
 /// true.  Without this guard the loading.html title "Messenger X" (which
@@ -34,5 +39,111 @@ fn on_navigation_sets_messenger_com_navigated_for_messenger_host() {
     assert!(
         SOURCE.contains("messenger_com_navigated_nav"),
         "on_navigation must reference messenger_com_navigated_nav to set the flag"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// page_load_stable guard (macOS SPA false-positive fix)
+// ---------------------------------------------------------------------------
+
+/// On macOS, `had_good_title` may only be set when `page_load_stable` is also
+/// `true`.  WKWebView emits title="" during every SPA navigation (not just
+/// after a real crash), so without this guard any mid-session thread navigation
+/// would trigger CrashDetect.
+#[test]
+fn had_good_title_arming_is_gated_on_page_load_stable_on_macos() {
+    assert!(
+        SOURCE.contains("|| page_load_stable.load"),
+        "had_good_title arming must include a page_load_stable gate for macOS"
+    );
+}
+
+/// The CrashDetect fire condition must also be gated on `page_load_stable` on
+/// macOS so that an already-armed `had_good_title` cannot fire CrashDetect
+/// during a normal SPA navigation (where the title briefly becomes "").
+#[test]
+fn crash_detect_fire_is_gated_on_page_load_stable_on_macos() {
+    // There must be at least two occurrences of the page_load_stable gate —
+    // one for had_good_title arming and one for the CrashDetect fire condition.
+    let count = SOURCE.matches("|| page_load_stable.load").count();
+    assert!(
+        count >= 2,
+        "page_load_stable gate must appear in both had_good_title arming \
+         and the CrashDetect fire condition; found {count} occurrence(s)"
+    );
+}
+
+/// The `on_navigation` handler must reset `page_load_stable` to `false` for
+/// macOS when a www.messenger.com navigation starts.  This ensures a new SPA
+/// transition is not treated as stable until `on_page_load::Finished` fires.
+#[test]
+fn on_navigation_resets_page_load_stable_on_macos() {
+    // Assert the actual reset call exists — `page_load_stable_nav` only
+    // appears in the on_navigation handler, so this uniquely identifies the
+    // correct store. Checking for the full call rather than just the variable
+    // name avoids a false positive where the variable is referenced but the
+    // store is absent.
+    assert!(
+        SOURCE.contains("page_load_stable_nav.store(false, std::sync::atomic::Ordering::Relaxed)"),
+        "on_navigation must call page_load_stable_nav.store(false, ...) to reset stability"
+    );
+    // The reset must be guarded by `if cfg!(target_os = "macos")` so that the
+    // condition evaluates to `false` at runtime on Linux/Windows (where
+    // WebKitGTK/WebView2 do not clear the title during normal SPA navigation);
+    // the optimizer then removes the dead branch.  We check both parts
+    // independently to avoid whitespace-sensitive multi-line assertions.
+    assert!(
+        SOURCE.contains("if cfg!(target_os = \"macos\") {"),
+        "page_load_stable_nav reset must be guarded by if cfg!(target_os = \"macos\")"
+    );
+}
+
+/// The `on_page_load` handler must set `page_load_stable` to `true` when the
+/// `Finished` event fires for www.messenger.com on macOS.  Without this the
+/// crash detector would never re-arm after a navigation.
+#[test]
+fn on_page_load_sets_page_load_stable_true_on_finished() {
+    assert!(
+        SOURCE.contains("page_load_stable_pl"),
+        "on_page_load must reference page_load_stable_pl to set stability flag"
+    );
+    // The setter must be guarded by `cfg!(target_os = "macos") &&
+    // matches!(payload.event(), PageLoadEvent::Finished)`.  This combined
+    // condition is unique to the on_page_load handler and avoids matching
+    // any of the many other `#[cfg(target_os = "macos")]` attributes
+    // elsewhere in lib.rs.
+    assert!(
+        SOURCE.contains(
+            "cfg!(target_os = \"macos\") && matches!(payload.event(), PageLoadEvent::Finished)"
+        ),
+        "page_load_stable setter must use cfg!(target_os = \"macos\") && matches!(...Finished)"
+    );
+    // The store call must set the flag to true.
+    assert!(
+        SOURCE.contains("page_load_stable_pl.store(true, std::sync::atomic::Ordering::Relaxed)"),
+        "on_page_load must call page_load_stable_pl.store(true, ...) on Finished"
+    );
+}
+
+/// When the max-reload limit is reached the `else` branch must reset
+/// `had_good_title` to `false` (all platforms).  Without this, every subsequent
+/// empty-title event — from a real crash before the recovery page sets its title
+/// (Linux: GStreamer crash mid-load) or from a macOS SPA navigation — would
+/// immediately re-trigger the else branch, creating an infinite
+/// navigate-to-root loop.
+#[test]
+fn max_reloads_else_resets_had_good_title_to_break_loop() {
+    // There must be at least two `had_good_title.store(false, ...)` calls:
+    //   1. In the `< MAX_CRASH_RELOADS` reload branch (existing guard).
+    //   2. In the `else` (max-reloads-exceeded) branch (the new cross-platform fix).
+    // Asserting the count directly verifies the code reset exists in both
+    // branches rather than relying on comment text.
+    let count = SOURCE
+        .matches("had_good_title.store(false, std::sync::atomic::Ordering::Relaxed)")
+        .count();
+    assert!(
+        count >= 2,
+        "had_good_title.store(false, ...) must appear in both the reload branch and \
+         the max-reloads else branch to prevent the infinite loop; found {count} occurrence(s)"
     );
 }


### PR DESCRIPTION
## Problem

macOS WKWebView emits `title=""` on **every** SPA navigation (not only after a real crash). After a good page load arms `had_good_title = true`, navigating to a thread URL produces an empty title → CrashDetect fires a false reload. After three such false positives the max-reloads `else` branch fired, but `had_good_title` was **never reset** there — so every subsequent empty-title SPA navigation immediately re-triggered the `else` branch, causing an infinite `navigate(root)` → SPA redirect to thread → `title=""` → `else` again loop.

Linux/Windows are unaffected by the false-positive trigger (WebKitGTK and WebView2 do NOT clear the title during clean SPA navigation), but the missing `had_good_title` reset in the `else` branch was a latent cross-platform bug (e.g. Linux: GStreamer crash mid-load before "Messenger" title is set).

## Fixes

### Fix 1 — `page_load_stable` guard (macOS-only)

- New `Arc<AtomicBool>` `page_load_stable` (initial `false`).
- Reset to `false` in `on_navigation` for `www.messenger.com` (`cfg!(target_os = "macos")` guard).
- Set to `true` in `on_page_load::Finished` for `www.messenger.com` (`#[cfg(target_os = "macos")]` guard).
- `had_good_title` arming and CrashDetect fire are both gated on `(!cfg!(target_os = "macos") || page_load_stable)` — the short-circuit makes this a no-op on Linux/Windows, preserving existing crash detection there unchanged.

### Fix 2 — `had_good_title` reset in `else` branch (all platforms)

Added `had_good_title.store(false)` (no `#[cfg]`) at the start of the max-reloads `else` branch. Prevents the branch from immediately re-firing if `title=""` arrives before the recovery page has set a good title (Linux: GStreamer crash mid-load; macOS: residual SPA navigation).

### Real crash detection preserved

- **macOS**: Real WKWebView crash happens while page is stable → `page_load_stable = true` → CrashDetect fires correctly.
- **Linux**: `!cfg!(macos)` short-circuits to `true` → unchanged; GStreamer crash (`title=""` on real crash) still detected; `post_crash_proxy_block` remains the GStreamer mitigation.
- **Windows**: Same short-circuit as Linux; no known crash scenario.

## Tests

5 new regression tests added to `src-tauri/tests/crash_detect.rs` (7 total):
- `had_good_title_arming_is_gated_on_page_load_stable_on_macos`
- `crash_detect_fire_is_gated_on_page_load_stable_on_macos`
- `on_navigation_resets_page_load_stable_on_macos`
- `on_page_load_sets_page_load_stable_true_on_finished`
- `max_reloads_else_resets_had_good_title_to_break_loop`

All 84 tests pass (`cargo test`). `cargo clippy` and `tsc --noEmit` clean.