### PR TITLE
fix: Linux bugs — all-platform page_load_stable, UA Chrome 136, log dedup, media-error logging + audit fixes

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2858,25 +2858,23 @@ struct SenderHintCache {
 
 /// Opens the Messenger X log file on Linux.
 ///
-/// Linux has no universal GUI log viewer (no equivalent to macOS Console.app),
-/// but every Linux system with a display has *some* terminal emulator, and
-/// `less` is POSIX-standard.  The terminal path is therefore tried first.
+/// Every Linux desktop ships with a text editor registered for `text/plain`,
+/// so `xdg-open` on a `.txt` file is the primary — and usually sufficient —
+/// approach.  `.log` files often have no MIME handler registered, so a
+/// `/tmp/messengerx-log.txt` symlink is used instead of the real path.
 ///
 /// All spawns strip `LD_LIBRARY_PATH`/`LD_PRELOAD` — the AppImage runtime
 /// injects these with stale paths, causing child processes to fail silently
-/// (same root cause fixed for `notify-send` in v1.4.1).
+/// (same root cause as the `notify-send` fix in v1.4.1).
 ///
 /// Strategy — first success wins:
-///   1. **Terminal + `less`** — `x-terminal-emulator` (Debian/Ubuntu/Mint
-///      update-alternatives standard), then `xterm` (X11 base, near-universal),
-///      then desktop-specific emulators.  Always works on any Linux with a
-///      display; `less` is always available.
-///   2. **`xdg-open` on a `/tmp/messengerx-log.txt` symlink** — `.log` files
-///      often have no xdg MIME handler, but `.txt` (`text/plain`) is always
-///      associated with the user's default text editor regardless of which
-///      DE or editor they use (GNOME, KDE, Xfce, Cinnamon, MATE, LXQt…).
-///   3. **`xdg-open` on the log directory** — opens the file manager; always
-///      works as an absolute last resort.
+///   1. **`xdg-open` on `/tmp/messengerx-log.txt` symlink** — opens in the
+///      user's default text editor (gedit, kate, mousepad, xed, VS Code, …)
+///      regardless of which DE or editor they have installed.
+///   2. **Terminal + `less`** — fallback if `xdg-open` is absent or fails.
+///      `x-terminal-emulator` (Debian/Ubuntu/Mint update-alternatives standard)
+///      then `xterm` (X11 base, near-universal), then others.
+///   3. **`xdg-open` on the log directory** — file-manager last resort.
 #[cfg(target_os = "linux")]
 fn open_log_on_linux(log_dir: &std::path::Path, log_file: &std::path::Path) {
     let file_exists = log_file.exists();
@@ -2884,85 +2882,81 @@ fn open_log_on_linux(log_dir: &std::path::Path, log_file: &std::path::Path) {
 
     if file_exists {
         // -------------------------------------------------------------------
-        // 1.  Terminal + less  — universal primary path.
+        // 1.  xdg-open via .txt symlink — opens in the default text editor.
         //
-        // x-terminal-emulator is the Debian/Ubuntu/Mint update-alternatives
-        // entry; it points to whatever terminal the user has configured as
-        // default, so it works across distros without knowing the exact binary.
-        // xterm is in the X11 base and is available on virtually every Linux
-        // desktop installation as a fallback.
-        //
-        // The log file path is passed as a direct argument (no sh -c wrapping
-        // needed; Command::arg handles spaces correctly without shell quoting).
+        // Every Linux desktop distro registers a text editor for text/plain.
+        // .log files often have no handler, so we symlink to .txt so that
+        // xdg-open picks the correct MIME type and launches the editor the
+        // user already has (gedit, kate, mousepad, xed, VS Code, etc.).
+        // AppImage env vars are stripped so xdg-open loads system libraries.
         // -------------------------------------------------------------------
-        let terminals: &[(&str, &[&str])] = &[
-            ("x-terminal-emulator", &["-e", "less"]),
-            ("xterm",               &["-e", "less"]),
-            ("gnome-terminal",      &["--", "less"]),
-            ("xfce4-terminal",      &["-e", "less"]),
-            ("konsole",             &["-e", "less"]),
-            ("mate-terminal",       &["-e", "less"]),
-            ("lxterminal",          &["-e", "less"]),
-            ("tilix",               &["-e", "less"]),
-        ];
-        for (term, pre) in terminals {
-            match std::process::Command::new(term)
-                .args(*pre)
-                .arg(log_file)
-                .env_remove("LD_LIBRARY_PATH")
-                .env_remove("LD_PRELOAD")
-                .spawn()
-            {
-                Ok(_) => {
-                    log::info!("[MessengerX] view_logs: opened in terminal {term}");
-                    opened = true;
-                    break;
-                }
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                Err(e) => log::warn!("[MessengerX] view_logs: {term} error: {e}"),
+        let tmp_link = std::env::temp_dir().join("messengerx-log.txt");
+        let _ = std::fs::remove_file(&tmp_link);
+        let target = if std::os::unix::fs::symlink(log_file, &tmp_link).is_ok() {
+            log::info!("[MessengerX] view_logs: created .txt symlink");
+            tmp_link.as_path()
+        } else {
+            log::warn!("[MessengerX] view_logs: symlink failed, using .log directly");
+            log_file
+        };
+        match std::process::Command::new("xdg-open")
+            .arg(target)
+            .env_remove("LD_LIBRARY_PATH")
+            .env_remove("LD_PRELOAD")
+            .spawn()
+        {
+            Ok(_) => {
+                log::info!("[MessengerX] view_logs: xdg-open on {}", target.display());
+                opened = true;
+            }
+            Err(e) => {
+                log::warn!("[MessengerX] view_logs: xdg-open failed: {e}");
+                let _ = std::fs::remove_file(&tmp_link);
             }
         }
 
         // -------------------------------------------------------------------
-        // 2.  xdg-open via a .txt symlink — GUI text editor fallback.
+        // 2.  Terminal + less — fallback when xdg-open is absent or fails.
         //
-        // .log files often have no registered xdg MIME handler so
-        // xdg-open on the real file silently does nothing.  A symlink named
-        // .txt causes xdg-open to detect text/plain MIME and open the file
-        // in whatever the user's default text editor is — no hard-coded editor
-        // names needed, works with VS Code, gedit, kate, xed, mousepad, etc.
+        // x-terminal-emulator is the Debian/Ubuntu/Mint update-alternatives
+        // entry pointing to the user's configured default terminal.
+        // xterm is in the X11 base and is available on virtually every Linux
+        // desktop installation.  The log file path is passed as a direct arg
+        // (Command::arg handles spaces; no sh -c quoting needed).
         // -------------------------------------------------------------------
         if !opened {
-            let tmp_link = std::env::temp_dir().join("messengerx-log.txt");
-            let _ = std::fs::remove_file(&tmp_link);
-            let target = if std::os::unix::fs::symlink(log_file, &tmp_link).is_ok() {
-                log::info!("[MessengerX] view_logs: created .txt symlink");
-                tmp_link.as_path()
-            } else {
-                log::warn!("[MessengerX] view_logs: symlink failed, using .log directly");
-                log_file
-            };
-            match std::process::Command::new("xdg-open")
-                .arg(target)
-                .env_remove("LD_LIBRARY_PATH")
-                .env_remove("LD_PRELOAD")
-                .spawn()
-            {
-                Ok(_) => {
-                    log::info!("[MessengerX] view_logs: xdg-open on {}", target.display());
-                    opened = true;
-                }
-                Err(e) => {
-                    log::warn!("[MessengerX] view_logs: xdg-open failed: {e}");
-                    let _ = std::fs::remove_file(&tmp_link);
+            let terminals: &[(&str, &[&str])] = &[
+                ("x-terminal-emulator", &["-e", "less"]),
+                ("xterm",               &["-e", "less"]),
+                ("gnome-terminal",      &["--", "less"]),
+                ("xfce4-terminal",      &["-e", "less"]),
+                ("konsole",             &["-e", "less"]),
+                ("mate-terminal",       &["-e", "less"]),
+                ("lxterminal",          &["-e", "less"]),
+                ("tilix",               &["-e", "less"]),
+            ];
+            for (term, pre) in terminals {
+                match std::process::Command::new(term)
+                    .args(*pre)
+                    .arg(log_file)
+                    .env_remove("LD_LIBRARY_PATH")
+                    .env_remove("LD_PRELOAD")
+                    .spawn()
+                {
+                    Ok(_) => {
+                        log::info!("[MessengerX] view_logs: opened in terminal {term}");
+                        opened = true;
+                        break;
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(e) => log::warn!("[MessengerX] view_logs: {term} error: {e}"),
                 }
             }
         }
     }
 
     // -----------------------------------------------------------------------
-    // 3.  Open the log directory in the file manager — absolute last resort.
-    //     xdg-open on a directory always works on any desktop.
+    // 3.  Open the log directory — file manager, absolute last resort.
     // -----------------------------------------------------------------------
     if !opened {
         let _ = std::fs::create_dir_all(log_dir);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2250,7 +2250,7 @@ const MEDIA_ERROR_LOGGER_SCRIPT: &str = concat!(
                 mlog('failed <' + t.tagName.toLowerCase() + '> src=' +
                      JSON.stringify(src) + ' v=' + APP_VERSION);
             } catch(_) {}
-        }, true /* capture phase — catches errors from all descendant frames */);
+        }, true /* capture phase — catches errors from same-origin frames; cross-origin iframes excluded by browser SOP */);
         mlog('listener registered v=' + APP_VERSION);
     } catch(e) {
         mlog('register FAILED: ' + (e && e.message ? e.message : String(e)));
@@ -3419,8 +3419,6 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                 // Guard: had_good_title is reset before each reload so that
                 // a series of back-to-back crashes doesn't bypass the count.
                 //
-                // macOS vs Linux/Windows:
-                //   • macOS WKWebView emits title="" during EVERY SPA
                 // ---------------------------------------------------------
                 // CrashDetect: `had_good_title` arming and fire condition.
                 //
@@ -3447,6 +3445,23 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                 // this guard it would arm the crash detector — causing a false-
                 // positive CrashDetect when the title briefly clears during the
                 // initial navigation.
+                //
+                // Recovery: if `on_page_load::Finished` was not received (e.g.,
+                // WebKitGTK SPA thread navigation may not fire Finished), a good
+                // Messenger title re-arms `page_load_stable` so CrashDetect is
+                // not permanently disarmed on Linux after the first SPA nav.
+                if title.contains("Messenger")
+                    && !title.trim().is_empty()
+                    && messenger_com_navigated
+                        .load(std::sync::atomic::Ordering::Relaxed)
+                    && !page_load_stable.load(std::sync::atomic::Ordering::Relaxed)
+                {
+                    page_load_stable.store(true, std::sync::atomic::Ordering::Relaxed);
+                    log::info!(
+                        "[MessengerX][CrashDetect] page_load_stable=true \
+                         (good-title recovery — on_page_load::Finished not received)"
+                    );
+                }
                 if title.contains("Messenger")
                     && !title.trim().is_empty()
                     && messenger_com_navigated

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2856,6 +2856,107 @@ struct SenderHintCache {
     retained: Option<(String, std::time::Instant)>,
 }
 
+/// Opens the Messenger X log file on Linux, working around AppImage
+/// `LD_LIBRARY_PATH`/`LD_PRELOAD` environment contamination that causes
+/// `xdg-open` (and `tauri-plugin-opener`) to fail silently (same root cause
+/// fixed for `notify-send` in v1.4.1).
+///
+/// Strategy — first success wins:
+///   1. Known text editors: `xed`, `gedit`, `kate`, `mousepad`, `pluma`, `geany`
+///   2. Terminal emulator running `less`: `x-terminal-emulator`, `xterm`,
+///      `gnome-terminal`, `xfce4-terminal`, `konsole`, `tilix`
+///   3. `xdg-open` on the log file (best-effort; may silently no-op if no MIME handler)
+///   4. `xdg-open` on the log directory (file-manager fallback — always works)
+#[cfg(target_os = "linux")]
+fn open_log_on_linux(log_dir: &std::path::Path, log_file: &std::path::Path) {
+    let file_exists = log_file.exists();
+    let mut opened = false;
+
+    if file_exists {
+        // 1. Try text editors (clean env to strip AppImage LD_LIBRARY_PATH).
+        for editor in &["xed", "gedit", "kate", "mousepad", "pluma", "geany"] {
+            match std::process::Command::new(editor)
+                .arg(log_file)
+                .env_remove("LD_LIBRARY_PATH")
+                .env_remove("LD_PRELOAD")
+                .spawn()
+            {
+                Ok(_) => {
+                    log::info!("[MessengerX] view_logs: opened with {editor}");
+                    opened = true;
+                    break;
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => log::warn!("[MessengerX] view_logs: {editor} error: {e}"),
+            }
+        }
+
+        // 2. Terminal fallback — run `less` inside whatever terminal is available.
+        //    MESSENGERX_LOG env var avoids shell-quoting issues with spaces in paths.
+        if !opened {
+            let sh_cmd =
+                "less \"$MESSENGERX_LOG\"; read -rp 'Press Enter to close...'";
+            let terminals: &[(&str, &[&str])] = &[
+                ("x-terminal-emulator", &["-e", "sh", "-c"]),
+                ("xterm", &["-e", "sh", "-c"]),
+                ("gnome-terminal", &["--", "sh", "-c"]),
+                ("xfce4-terminal", &["-e", "sh", "-c"]),
+                ("konsole", &["-e", "sh", "-c"]),
+                ("tilix", &["-e", "sh", "-c"]),
+            ];
+            for (term, pre) in terminals {
+                match std::process::Command::new(term)
+                    .args(*pre)
+                    .arg(sh_cmd)
+                    .env("MESSENGERX_LOG", log_file)
+                    .env_remove("LD_LIBRARY_PATH")
+                    .env_remove("LD_PRELOAD")
+                    .spawn()
+                {
+                    Ok(_) => {
+                        log::info!("[MessengerX] view_logs: opened in terminal {term}");
+                        opened = true;
+                        break;
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(e) => log::warn!("[MessengerX] view_logs: {term} error: {e}"),
+                }
+            }
+        }
+
+        // 3. xdg-open on the file (best-effort; silently no-ops if no MIME handler
+        //    but AppImage env is stripped so at least the binary itself can run).
+        if !opened {
+            match std::process::Command::new("xdg-open")
+                .arg(log_file)
+                .env_remove("LD_LIBRARY_PATH")
+                .env_remove("LD_PRELOAD")
+                .spawn()
+            {
+                Ok(_) => {
+                    log::info!("[MessengerX] view_logs: xdg-open on file (best-effort)");
+                    opened = true;
+                }
+                Err(e) => log::warn!("[MessengerX] view_logs: xdg-open file failed: {e}"),
+            }
+        }
+    }
+
+    // 4. Open the log directory in the file manager (always works on any desktop).
+    if !opened {
+        let _ = std::fs::create_dir_all(log_dir);
+        match std::process::Command::new("xdg-open")
+            .arg(log_dir)
+            .env_remove("LD_LIBRARY_PATH")
+            .env_remove("LD_PRELOAD")
+            .spawn()
+        {
+            Ok(_) => log::info!("[MessengerX] view_logs: opened log directory in file manager"),
+            Err(e) => log::warn!("[MessengerX] view_logs: xdg-open dir failed: {e}"),
+        }
+    }
+}
+
 /// Run the Tauri application.
 ///
 /// Registers all plugins, builds the main webview window with JS injection
@@ -4621,20 +4722,35 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
 
                     // ---- View Logs ----
                     "view_logs" => {
-                        use tauri_plugin_opener::OpenerExt;
                         if let Ok(log_dir) = handle.path().app_log_dir() {
                             let log_file = log_dir.join("messengerx.log");
-                            if log_file.exists() {
-                                let _ = handle.opener().open_path(
-                                    log_file.to_string_lossy().into_owned(),
-                                    None::<&str>,
-                                );
-                            } else {
-                                let _ = std::fs::create_dir_all(&log_dir);
-                                let _ = handle.opener().open_path(
-                                    log_dir.to_string_lossy().into_owned(),
-                                    None::<&str>,
-                                );
+                            log::info!(
+                                "[MessengerX] view_logs: path={} exists={}",
+                                log_file.display(),
+                                log_file.exists()
+                            );
+                            // On Linux (AppImage): use open_log_on_linux() which
+                            // strips LD_LIBRARY_PATH/LD_PRELOAD before spawning
+                            // and tries text editors + terminal before xdg-open.
+                            #[cfg(target_os = "linux")]
+                            open_log_on_linux(&log_dir, &log_file);
+
+                            #[cfg(not(target_os = "linux"))]
+                            {
+                                use tauri_plugin_opener::OpenerExt;
+                                let p = if log_file.exists() {
+                                    log_file.to_string_lossy().into_owned()
+                                } else {
+                                    let _ = std::fs::create_dir_all(&log_dir);
+                                    log_dir.to_string_lossy().into_owned()
+                                };
+                                if let Err(e) =
+                                    handle.opener().open_path(p, None::<&str>)
+                                {
+                                    log::warn!(
+                                        "[MessengerX] view_logs: opener failed: {e}"
+                                    );
+                                }
                             }
                         }
                     }
@@ -5119,15 +5235,19 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                     use tauri_plugin_opener::OpenerExt;
                     if let Ok(log_dir) = h.path().app_log_dir() {
                         let log_file = log_dir.join("messengerx.log");
-                        if log_file.exists() {
-                            let _ = h
-                                .opener()
-                                .open_path(log_file.to_string_lossy().into_owned(), None::<&str>);
+                        log::info!(
+                            "[MessengerX] view_logs: path={} exists={}",
+                            log_file.display(),
+                            log_file.exists()
+                        );
+                        let p = if log_file.exists() {
+                            log_file.to_string_lossy().into_owned()
                         } else {
                             let _ = std::fs::create_dir_all(&log_dir);
-                            let _ = h
-                                .opener()
-                                .open_path(log_dir.to_string_lossy().into_owned(), None::<&str>);
+                            log_dir.to_string_lossy().into_owned()
+                        };
+                        if let Err(e) = h.opener().open_path(p, None::<&str>) {
+                            log::warn!("[MessengerX] view_logs: opener failed: {e}");
                         }
                     }
                 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2856,93 +2856,114 @@ struct SenderHintCache {
     retained: Option<(String, std::time::Instant)>,
 }
 
-/// Opens the Messenger X log file on Linux, working around AppImage
-/// `LD_LIBRARY_PATH`/`LD_PRELOAD` environment contamination that causes
-/// `xdg-open` (and `tauri-plugin-opener`) to fail silently (same root cause
-/// fixed for `notify-send` in v1.4.1).
+/// Opens the Messenger X log file on Linux.
+///
+/// Linux has no universal GUI log viewer (no equivalent to macOS Console.app),
+/// but every Linux system with a display has *some* terminal emulator, and
+/// `less` is POSIX-standard.  The terminal path is therefore tried first.
+///
+/// All spawns strip `LD_LIBRARY_PATH`/`LD_PRELOAD` — the AppImage runtime
+/// injects these with stale paths, causing child processes to fail silently
+/// (same root cause fixed for `notify-send` in v1.4.1).
 ///
 /// Strategy — first success wins:
-///   1. Known text editors: `xed`, `gedit`, `kate`, `mousepad`, `pluma`, `geany`
-///   2. Terminal emulator running `less`: `x-terminal-emulator`, `xterm`,
-///      `gnome-terminal`, `xfce4-terminal`, `konsole`, `tilix`
-///   3. `xdg-open` on the log file (best-effort; may silently no-op if no MIME handler)
-///   4. `xdg-open` on the log directory (file-manager fallback — always works)
+///   1. **Terminal + `less`** — `x-terminal-emulator` (Debian/Ubuntu/Mint
+///      update-alternatives standard), then `xterm` (X11 base, near-universal),
+///      then desktop-specific emulators.  Always works on any Linux with a
+///      display; `less` is always available.
+///   2. **`xdg-open` on a `/tmp/messengerx-log.txt` symlink** — `.log` files
+///      often have no xdg MIME handler, but `.txt` (`text/plain`) is always
+///      associated with the user's default text editor regardless of which
+///      DE or editor they use (GNOME, KDE, Xfce, Cinnamon, MATE, LXQt…).
+///   3. **`xdg-open` on the log directory** — opens the file manager; always
+///      works as an absolute last resort.
 #[cfg(target_os = "linux")]
 fn open_log_on_linux(log_dir: &std::path::Path, log_file: &std::path::Path) {
     let file_exists = log_file.exists();
     let mut opened = false;
 
     if file_exists {
-        // 1. Try text editors (clean env to strip AppImage LD_LIBRARY_PATH).
-        for editor in &["xed", "gedit", "kate", "mousepad", "pluma", "geany"] {
-            match std::process::Command::new(editor)
+        // -------------------------------------------------------------------
+        // 1.  Terminal + less  — universal primary path.
+        //
+        // x-terminal-emulator is the Debian/Ubuntu/Mint update-alternatives
+        // entry; it points to whatever terminal the user has configured as
+        // default, so it works across distros without knowing the exact binary.
+        // xterm is in the X11 base and is available on virtually every Linux
+        // desktop installation as a fallback.
+        //
+        // The log file path is passed as a direct argument (no sh -c wrapping
+        // needed; Command::arg handles spaces correctly without shell quoting).
+        // -------------------------------------------------------------------
+        let terminals: &[(&str, &[&str])] = &[
+            ("x-terminal-emulator", &["-e", "less"]),
+            ("xterm",               &["-e", "less"]),
+            ("gnome-terminal",      &["--", "less"]),
+            ("xfce4-terminal",      &["-e", "less"]),
+            ("konsole",             &["-e", "less"]),
+            ("mate-terminal",       &["-e", "less"]),
+            ("lxterminal",          &["-e", "less"]),
+            ("tilix",               &["-e", "less"]),
+        ];
+        for (term, pre) in terminals {
+            match std::process::Command::new(term)
+                .args(*pre)
                 .arg(log_file)
                 .env_remove("LD_LIBRARY_PATH")
                 .env_remove("LD_PRELOAD")
                 .spawn()
             {
                 Ok(_) => {
-                    log::info!("[MessengerX] view_logs: opened with {editor}");
+                    log::info!("[MessengerX] view_logs: opened in terminal {term}");
                     opened = true;
                     break;
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                Err(e) => log::warn!("[MessengerX] view_logs: {editor} error: {e}"),
+                Err(e) => log::warn!("[MessengerX] view_logs: {term} error: {e}"),
             }
         }
 
-        // 2. Terminal fallback — run `less` inside whatever terminal is available.
-        //    MESSENGERX_LOG env var avoids shell-quoting issues with spaces in paths.
+        // -------------------------------------------------------------------
+        // 2.  xdg-open via a .txt symlink — GUI text editor fallback.
+        //
+        // .log files often have no registered xdg MIME handler so
+        // xdg-open on the real file silently does nothing.  A symlink named
+        // .txt causes xdg-open to detect text/plain MIME and open the file
+        // in whatever the user's default text editor is — no hard-coded editor
+        // names needed, works with VS Code, gedit, kate, xed, mousepad, etc.
+        // -------------------------------------------------------------------
         if !opened {
-            let sh_cmd =
-                "less \"$MESSENGERX_LOG\"; read -rp 'Press Enter to close...'";
-            let terminals: &[(&str, &[&str])] = &[
-                ("x-terminal-emulator", &["-e", "sh", "-c"]),
-                ("xterm", &["-e", "sh", "-c"]),
-                ("gnome-terminal", &["--", "sh", "-c"]),
-                ("xfce4-terminal", &["-e", "sh", "-c"]),
-                ("konsole", &["-e", "sh", "-c"]),
-                ("tilix", &["-e", "sh", "-c"]),
-            ];
-            for (term, pre) in terminals {
-                match std::process::Command::new(term)
-                    .args(*pre)
-                    .arg(sh_cmd)
-                    .env("MESSENGERX_LOG", log_file)
-                    .env_remove("LD_LIBRARY_PATH")
-                    .env_remove("LD_PRELOAD")
-                    .spawn()
-                {
-                    Ok(_) => {
-                        log::info!("[MessengerX] view_logs: opened in terminal {term}");
-                        opened = true;
-                        break;
-                    }
-                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                    Err(e) => log::warn!("[MessengerX] view_logs: {term} error: {e}"),
-                }
-            }
-        }
-
-        // 3. xdg-open on the file (best-effort; silently no-ops if no MIME handler
-        //    but AppImage env is stripped so at least the binary itself can run).
-        if !opened {
+            let tmp_link = std::env::temp_dir().join("messengerx-log.txt");
+            let _ = std::fs::remove_file(&tmp_link);
+            let target = if std::os::unix::fs::symlink(log_file, &tmp_link).is_ok() {
+                log::info!("[MessengerX] view_logs: created .txt symlink");
+                tmp_link.as_path()
+            } else {
+                log::warn!("[MessengerX] view_logs: symlink failed, using .log directly");
+                log_file
+            };
             match std::process::Command::new("xdg-open")
-                .arg(log_file)
+                .arg(target)
                 .env_remove("LD_LIBRARY_PATH")
                 .env_remove("LD_PRELOAD")
                 .spawn()
             {
                 Ok(_) => {
-                    log::info!("[MessengerX] view_logs: xdg-open on file (best-effort)");
+                    log::info!("[MessengerX] view_logs: xdg-open on {}", target.display());
                     opened = true;
                 }
-                Err(e) => log::warn!("[MessengerX] view_logs: xdg-open file failed: {e}"),
+                Err(e) => {
+                    log::warn!("[MessengerX] view_logs: xdg-open failed: {e}");
+                    let _ = std::fs::remove_file(&tmp_link);
+                }
             }
         }
     }
 
-    // 4. Open the log directory in the file manager (always works on any desktop).
+    // -----------------------------------------------------------------------
+    // 3.  Open the log directory in the file manager — absolute last resort.
+    //     xdg-open on a directory always works on any desktop.
+    // -----------------------------------------------------------------------
     if !opened {
         let _ = std::fs::create_dir_all(log_dir);
         match std::process::Command::new("xdg-open")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2201,6 +2201,64 @@ const AUDIO_HOOK_SCRIPT: &str = concat!(
 "#
 );
 
+/// JavaScript snippet that captures failed media-resource loads (`<img>`,
+/// `<video>`, `<audio>`, `<source>`) at the `window` capture phase and forwards
+/// each unique failed URL to the Rust log file via `js_log`.
+///
+/// This is passive diagnostic telemetry: it fires only when a media element
+/// fails to load (network error, blocked CDN domain, etc.) and deduplicates
+/// within the same page-load so the log is not flooded on retry loops.
+///
+/// Use-case: Linux users with DNS-level ad-blockers on their router may have
+/// certain CDN domains blocked.  GIFs and videos served from different CDN
+/// endpoints for DMs vs group chats may be affected differently.  The logged
+/// URL tells us (and the user) exactly which domain is being blocked without
+/// requiring them to open browser DevTools.
+///
+/// Log prefix: `[MediaErrorJS]`.
+const MEDIA_ERROR_LOGGER_SCRIPT: &str = concat!(
+    r#"
+(function() {
+    var APP_VERSION = ""#,
+    env!("CARGO_PKG_VERSION"),
+    r#"";
+
+    function mlog(msg) {
+        try {
+            window.__TAURI__.core.invoke('js_log', { message: '[MediaErrorJS] ' + msg });
+        } catch(_) {}
+    }
+
+    // Dedup set: only the first failure per URL per page-load is logged so
+    // that retry loops don't flood the log file.
+    var _seen = new Set();
+
+    try {
+        window.addEventListener('error', function(e) {
+            try {
+                var t = e.target;
+                if (!(t instanceof HTMLImageElement  ||
+                      t instanceof HTMLVideoElement  ||
+                      t instanceof HTMLAudioElement  ||
+                      t instanceof HTMLSourceElement)) {
+                    return;
+                }
+                var src = t.src || t.currentSrc || '(no-src)';
+                if (src.length > 200) { src = src.slice(0, 197) + '...'; }
+                if (_seen.has(src)) { return; }
+                _seen.add(src);
+                mlog('failed <' + t.tagName.toLowerCase() + '> src=' +
+                     JSON.stringify(src) + ' v=' + APP_VERSION);
+            } catch(_) {}
+        }, true /* capture phase — catches errors from all descendant frames */);
+        mlog('listener registered v=' + APP_VERSION);
+    } catch(e) {
+        mlog('register FAILED: ' + (e && e.message ? e.message : String(e)));
+    }
+})();
+"#
+);
+
 /// JavaScript snippet that triggers snapshot capture and forwards the HTML to
 /// Rust via `invoke('save_snapshot', …)`.  Called from the Rust snapshot timer.
 ///
@@ -2810,11 +2868,12 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(
             tauri_plugin_log::Builder::new()
-                .target(tauri_plugin_log::Target::new(
-                    tauri_plugin_log::TargetKind::LogDir {
+                .targets([
+                    tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Stdout),
+                    tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::LogDir {
                         file_name: Some("messengerx".to_string()),
-                    },
-                ))
+                    }),
+                ])
                 .max_file_size(500_000)
                 .rotation_strategy(tauri_plugin_log::RotationStrategy::KeepOne)
                 .build(),
@@ -2987,18 +3046,21 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     // macOS WKWebView.
     let messenger_com_navigated =
         std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-    // On macOS WKWebView the document title briefly becomes `""` during
-    // EVERY SPA navigation (not only after a real WebKit crash).  To avoid
-    // false-positive CrashDetect fires we track whether the page has
-    // finished loading:
+    // The document title briefly becomes `""` during certain events:
+    //   • macOS WKWebView: on EVERY SPA navigation (not only after a real
+    //     WebKit crash) — thread-to-thread navigation clears the title.
+    //   • Linux WebKitGTK: on `window.location.reload()` (e.g. appearance
+    //     toggle) AND on real WebKitWebProcess crashes.
+    // To avoid false-positive CrashDetect fires on both platforms we track
+    // whether the page has finished loading via `page_load_stable`:
     //   • Reset to `false` in `on_navigation` for www.messenger.com
     //     (navigation has started, page is not yet stable).
     //   • Set to `true` in `on_page_load::Finished` for www.messenger.com
     //     (DOMContentLoaded-equivalent; page is now stable).
-    // `had_good_title` may only be set on macOS when `page_load_stable`
-    // is `true`, and CrashDetect may only fire on macOS when it is `true`.
-    // On Linux/Windows the old behaviour is preserved (WebKitGTK /
-    // WebView2 do NOT emit `""` title during normal SPA navigation).
+    // `had_good_title` may only be set when `page_load_stable` is `true`,
+    // and CrashDetect may only fire when it is `true` (all platforms).
+    // Real crashes that happen AFTER the page has fully loaded still fire
+    // correctly because `page_load_stable` is `true` at that point.
     let page_load_stable =
         std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     // ------------------------------------------------------------------
@@ -3099,6 +3161,7 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         .initialization_script(UNREAD_OBSERVER_SCRIPT)
         .initialization_script(DIAGNOSTIC_TELEMETRY_SCRIPT)
         .initialization_script(AUDIO_HOOK_SCRIPT)
+        .initialization_script(MEDIA_ERROR_LOGGER_SCRIPT)
         .initialization_script(OFFLINE_DIALOG_HIDER_SCRIPT)
         .initialization_script(&offline_banner_script)
         .initialization_script(&zoom_init_script)
@@ -3148,7 +3211,7 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         .user_agent(
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) \
          AppleWebKit/537.36 (KHTML, like Gecko) \
-         Chrome/120.0.0.0 Safari/537.36",
+         Chrome/136.0.0.0 Safari/537.36",
         )
         // ------------------------------------------------------------------
         // Phase G: Rust-side title-change unread-count detection.
@@ -3358,46 +3421,48 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                 //
                 // macOS vs Linux/Windows:
                 //   • macOS WKWebView emits title="" during EVERY SPA
-                //     navigation (not only on crash) → page_load_stable
-                //     gate prevents false-positive CrashDetect fires during
-                //     normal thread navigation.
-                //   • Linux WebKitGTK / Windows WebView2 do NOT clear the
-                //     title during clean SPA navigation — title="" appears
-                //     only on a real WebKitWebProcess crash → the
-                //     page_load_stable gate short-circuits to `true` there
-                //     (!cfg!(target_os = "macos") == true) so crash
-                //     detection is unchanged on Linux/Windows.
+                // ---------------------------------------------------------
+                // CrashDetect: `had_good_title` arming and fire condition.
+                //
+                // `page_load_stable` (all platforms) gates both:
+                //   • Setting `had_good_title = true` — prevents arming
+                //     before the page has fully loaded after any navigation.
+                //   • The CrashDetect fire — prevents false positives while
+                //     the page is still loading (title="" is normal mid-load).
+                //
+                // This handles two distinct cases uniformly:
+                //   • macOS WKWebView: title="" during EVERY SPA navigation
+                //     (not just after a real crash) — the gate prevents
+                //     false-positive CrashDetect fires during normal thread
+                //     navigation.
+                //   • Linux WebKitGTK: title="" during `window.location.reload()`
+                //     (e.g. appearance toggle) — the gate prevents a false-
+                //     positive because `on_navigation` resets `page_load_stable`
+                //     to `false` before the reload and `on_page_load::Finished`
+                //     re-arms it once the page is stable again.
                 // ---------------------------------------------------------
                 // Only count a title as "good" once a real messenger.com
                 // navigation has been allowed.  The loading.html splash page
                 // title ("Messenger X") also contains "Messenger", so without
                 // this guard it would arm the crash detector — causing a false-
                 // positive CrashDetect when the title briefly clears during the
-                // initial SPA navigation on macOS WKWebView.
-                //
-                // On macOS we additionally require `page_load_stable == true`
-                // (set by on_page_load::Finished) because WKWebView emits
-                // title="" during EVERY SPA navigation, not only after a crash.
-                // On Linux/Windows this extra guard is skipped — WebKitGTK and
-                // WebView2 only emit title="" after real crashes.
+                // initial navigation.
                 if title.contains("Messenger")
                     && !title.trim().is_empty()
                     && messenger_com_navigated
                         .load(std::sync::atomic::Ordering::Relaxed)
-                    && (!cfg!(target_os = "macos")
-                        || page_load_stable.load(std::sync::atomic::Ordering::Relaxed))
+                    && page_load_stable.load(std::sync::atomic::Ordering::Relaxed)
                 {
                     had_good_title.store(true, std::sync::atomic::Ordering::Relaxed);
                 }
 
                 const MAX_CRASH_RELOADS: u32 = 3;
-                // On macOS also require page_load_stable so we don't fire
-                // during normal SPA navigation (WKWebView clears the title on
-                // every navigation, not just on crash).
+                // `page_load_stable` must be true (page fully loaded) before
+                // CrashDetect fires.  This prevents false positives while the
+                // page is loading after any navigation or reload on all platforms.
                 if title.trim().is_empty()
                     && had_good_title.load(std::sync::atomic::Ordering::Relaxed)
-                    && (!cfg!(target_os = "macos")
-                        || page_load_stable.load(std::sync::atomic::Ordering::Relaxed))
+                    && page_load_stable.load(std::sync::atomic::Ordering::Relaxed)
                 {
                     let prev_count =
                         crash_reload_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -3479,10 +3544,9 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         // This lets us pinpoint which phase accounts for the 27-second white-
         // screen gap observed on Win11 (WebView2 boot timing diagnostic).
         //
-        // On macOS, `Finished` for www.messenger.com additionally marks
+        // `Finished` for www.messenger.com additionally marks
         // `page_load_stable = true` so the CrashDetect gate is re-armed
-        // only after the SPA has fully settled (WKWebView emits title=""
-        // during every SPA navigation; we must not treat that as a crash).
+        // only after the page has fully settled (all platforms).
         // ------------------------------------------------------------------
         .on_page_load({
             let page_load_stable_pl = page_load_stable.clone();
@@ -3497,13 +3561,9 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                     payload.url(),
                     setup_started.elapsed().as_millis(),
                 );
-                // macOS only: re-arm the crash-detect stable flag once the
-                // page has finished loading for messenger.com.  Using
-                // `cfg!(target_os = "macos")` (a runtime bool) rather than
-                // `#[cfg(...)]` keeps `page_load_stable_pl` referenced in
-                // the closure body on all platforms, avoiding an
-                // unused-variable warning on Linux/Windows.
-                if cfg!(target_os = "macos") && matches!(payload.event(), PageLoadEvent::Finished) {
+                // All platforms: re-arm the crash-detect stable flag once the
+                // page has finished loading for messenger.com.
+                if matches!(payload.event(), PageLoadEvent::Finished) {
                     let host = payload.url().host_str().unwrap_or("");
                     if host == "www.messenger.com" {
                         page_load_stable_pl.store(true, std::sync::atomic::Ordering::Relaxed);
@@ -3549,12 +3609,11 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                 if host == "www.messenger.com" {
                     messenger_com_navigated_nav
                         .store(true, std::sync::atomic::Ordering::Relaxed);
-                    // On macOS, mark the page as not yet stable so the
-                    // empty-title SPA transition doesn't trigger CrashDetect.
+                    // Mark the page as not yet stable so that a transient
+                    // title="" during the load (macOS SPA navigation or Linux
+                    // window.location.reload()) doesn't trigger CrashDetect.
                     // Stability is restored by on_page_load::Finished.
-                    if cfg!(target_os = "macos") {
-                        page_load_stable_nav.store(false, std::sync::atomic::Ordering::Relaxed);
-                    }
+                    page_load_stable_nav.store(false, std::sync::atomic::Ordering::Relaxed);
                 }
 
                 // Post-crash fbsbx proxy block (Linux only).
@@ -4372,7 +4431,9 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                                  window.location.reload();",
                                 mode
                             );
-                            let _ = wv.eval(&script);
+                            if let Err(e) = wv.eval(&script) {
+                                log::warn!("[MessengerX][Appearance] eval failed: {e}");
+                            }
                             // Update window chrome theme (title bar) immediately.
                             let theme = match mode {
                                 "dark" => Some(tauri::Theme::Dark),
@@ -4891,7 +4952,9 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                              window.location.reload();",
                             mode
                         );
-                        let _ = wv.eval(&script);
+                        if let Err(e) = wv.eval(&script) {
+                            log::warn!("[MessengerX][Appearance] eval failed: {e}");
+                        }
                         // Update window chrome theme (title bar) immediately.
                         let theme = match mode {
                             "dark" => Some(tauri::Theme::Dark),

--- a/src-tauri/tests/crash_detect.rs
+++ b/src-tauri/tests/crash_detect.rs
@@ -1,7 +1,9 @@
 //! Regression tests: assert that the CrashDetect `had_good_title` arming guard
-//! (`messenger_com_navigated`) and the macOS `page_load_stable` SPA-navigation
-//! guard remain in place so that normal SPA title-clears and the `loading.html`
-//! splash-page title cannot trigger a false-positive crash-detection loop.
+//! (`messenger_com_navigated`) and the all-platform `page_load_stable`
+//! SPA-navigation / reload guard remain in place so that normal SPA title-clears,
+//! `window.location.reload()` (e.g. appearance toggle on Linux), and the
+//! `loading.html` splash-page title cannot trigger a false-positive crash-
+//! detection loop.
 //!
 //! These live in an integration-test file (not inside lib.rs) so that
 //! `include_str!("../src/lib.rs")` does NOT include the assertions themselves —
@@ -43,29 +45,31 @@ fn on_navigation_sets_messenger_com_navigated_for_messenger_host() {
 }
 
 // ---------------------------------------------------------------------------
-// page_load_stable guard (macOS SPA false-positive fix)
+// page_load_stable guard (all-platform SPA / reload false-positive fix)
 // ---------------------------------------------------------------------------
 
-/// On macOS, `had_good_title` may only be set when `page_load_stable` is also
-/// `true`.  WKWebView emits title="" during every SPA navigation (not just
-/// after a real crash), so without this guard any mid-session thread navigation
-/// would trigger CrashDetect.
+/// `had_good_title` must only be set when `page_load_stable` is also `true`.
+/// Both macOS WKWebView (title="" on every SPA navigation) and Linux
+/// WebKitGTK (`window.location.reload()` from the appearance toggle) transiently
+/// clear the document title — without this guard either would arm the crash
+/// detector prematurely.
 #[test]
 fn had_good_title_arming_is_gated_on_page_load_stable_on_macos() {
     assert!(
-        SOURCE.contains("|| page_load_stable.load"),
-        "had_good_title arming must include a page_load_stable gate for macOS"
+        SOURCE.contains("&& page_load_stable.load"),
+        "had_good_title arming must be guarded by && page_load_stable.load (all platforms)"
     );
 }
 
-/// The CrashDetect fire condition must also be gated on `page_load_stable` on
-/// macOS so that an already-armed `had_good_title` cannot fire CrashDetect
-/// during a normal SPA navigation (where the title briefly becomes "").
+/// The CrashDetect fire condition must also be gated on `page_load_stable` so
+/// that an already-armed `had_good_title` cannot fire CrashDetect while the
+/// page is still loading (title="" is normal during macOS SPA navigation and
+/// Linux appearance-toggle reload).
 #[test]
 fn crash_detect_fire_is_gated_on_page_load_stable_on_macos() {
     // There must be at least two occurrences of the page_load_stable gate —
     // one for had_good_title arming and one for the CrashDetect fire condition.
-    let count = SOURCE.matches("|| page_load_stable.load").count();
+    let count = SOURCE.matches("&& page_load_stable.load").count();
     assert!(
         count >= 2,
         "page_load_stable gate must appear in both had_good_title arming \
@@ -74,49 +78,51 @@ fn crash_detect_fire_is_gated_on_page_load_stable_on_macos() {
 }
 
 /// The `on_navigation` handler must reset `page_load_stable` to `false` for
-/// macOS when a www.messenger.com navigation starts.  This ensures a new SPA
-/// transition is not treated as stable until `on_page_load::Finished` fires.
+/// all platforms when a www.messenger.com navigation starts.  This ensures a
+/// new page transition is not treated as stable until `on_page_load::Finished`
+/// fires, preventing false-positive CrashDetect fires on macOS (SPA navigation)
+/// and Linux (appearance-toggle reload).
 #[test]
 fn on_navigation_resets_page_load_stable_on_macos() {
     // Assert the actual reset call exists — `page_load_stable_nav` only
     // appears in the on_navigation handler, so this uniquely identifies the
-    // correct store. Checking for the full call rather than just the variable
-    // name avoids a false positive where the variable is referenced but the
-    // store is absent.
+    // correct store.
     assert!(
         SOURCE.contains("page_load_stable_nav.store(false, std::sync::atomic::Ordering::Relaxed)"),
         "on_navigation must call page_load_stable_nav.store(false, ...) to reset stability"
     );
-    // The reset must be guarded by `if cfg!(target_os = "macos")` so that the
-    // condition evaluates to `false` at runtime on Linux/Windows (where
-    // WebKitGTK/WebView2 do not clear the title during normal SPA navigation);
-    // the optimizer then removes the dead branch.  We check both parts
-    // independently to avoid whitespace-sensitive multi-line assertions.
+    // The reset must NOT be wrapped in a platform guard — it applies to all
+    // platforms (macOS SPA navigation AND Linux appearance-toggle reload both
+    // require it).
     assert!(
-        SOURCE.contains("if cfg!(target_os = \"macos\") {"),
-        "page_load_stable_nav reset must be guarded by if cfg!(target_os = \"macos\")"
+        !SOURCE.contains("if cfg!(target_os = \"macos\") {\n                    page_load_stable_nav"),
+        "page_load_stable_nav reset must not be inside a macos-only cfg! guard"
     );
 }
 
 /// The `on_page_load` handler must set `page_load_stable` to `true` when the
-/// `Finished` event fires for www.messenger.com on macOS.  Without this the
-/// crash detector would never re-arm after a navigation.
+/// `Finished` event fires for www.messenger.com on all platforms.  Without this
+/// the crash detector would never re-arm after a navigation on any platform.
 #[test]
 fn on_page_load_sets_page_load_stable_true_on_finished() {
     assert!(
         SOURCE.contains("page_load_stable_pl"),
         "on_page_load must reference page_load_stable_pl to set stability flag"
     );
-    // The setter must be guarded by `cfg!(target_os = "macos") &&
-    // matches!(payload.event(), PageLoadEvent::Finished)`.  This combined
-    // condition is unique to the on_page_load handler and avoids matching
-    // any of the many other `#[cfg(target_os = "macos")]` attributes
-    // elsewhere in lib.rs.
+    // The setter must be guarded by `matches!(payload.event(), PageLoadEvent::Finished)`
+    // without a platform-only cfg! wrapper — it applies to all platforms.
     assert!(
         SOURCE.contains(
+            "matches!(payload.event(), PageLoadEvent::Finished)"
+        ),
+        "page_load_stable setter must use matches!(...Finished) (all platforms)"
+    );
+    // Must NOT be gated on a macOS-only condition any more.
+    assert!(
+        !SOURCE.contains(
             "cfg!(target_os = \"macos\") && matches!(payload.event(), PageLoadEvent::Finished)"
         ),
-        "page_load_stable setter must use cfg!(target_os = \"macos\") && matches!(...Finished)"
+        "page_load_stable setter must not be macOS-only; it must apply to all platforms"
     );
     // The store call must set the flag to true.
     assert!(

--- a/src-tauri/tests/crash_detect.rs
+++ b/src-tauri/tests/crash_detect.rs
@@ -153,3 +153,18 @@ fn max_reloads_else_resets_had_good_title_to_break_loop() {
          the max-reloads else branch to prevent the infinite loop; found {count} occurrence(s)"
     );
 }
+
+/// `on_document_title_changed` must recover `page_load_stable` to `true` when a
+/// good Messenger title is seen but `page_load_stable` is still `false` (i.e.,
+/// `on_page_load::Finished` was not received — possible on WebKitGTK where SPA
+/// thread navigation may not fire the `Finished` event).  Without this recovery,
+/// CrashDetect would be permanently disarmed on Linux after the first thread nav
+/// because `page_load_stable` would stay `false` for the rest of the session.
+#[test]
+fn good_title_recovery_sets_page_load_stable_when_finished_not_received() {
+    assert!(
+        SOURCE.contains("&& !page_load_stable.load"),
+        "on_document_title_changed must recover page_load_stable=true when a good title \
+         is seen but page_load_stable is still false (on_page_load::Finished not received)"
+    );
+}


### PR DESCRIPTION
## Summary

Four Linux-facing bug fixes + four post-commit audit fixes, all on `fix/linux-bugs`.

### Fix 1 — Appearance toggle reload loop on Linux (CrashDetect false-positive)
`window.location.reload()` on WebKitGTK briefly clears `title=""` — the same signal CrashDetect uses for a real crash. Extended `page_load_stable` guard to **all platforms** (was macOS-only). `on_navigation` resets `page_load_stable=false`; `on_page_load::Finished` re-arms it. Both `had_good_title` arming and the CrashDetect fire are gated universally. Cascading GIF picker failures (from `post_crash_proxy_block` blocking `fbsbx.com/maw_proxy_page`) are also resolved.

### Fix 2 — reCAPTCHA / stale User-Agent
Chrome 120 UA (~2.5 years old) flagged by Google reCAPTCHA bot-scoring. Updated to `Chrome/136.0.0.0`.

### Fix 3 — Duplicate log file
`tauri-plugin-log` `Builder::new()` creates a default `LogDir` target → `Messenger X.log`. Calling `.target(...)` appended a second log instead of replacing. Fixed with `.targets([Stdout, LogDir{messengerx}])`.

### Fix 4 — Media-error diagnostic logging (`MEDIA_ERROR_LOGGER_SCRIPT`)
Capture-phase JS error listener logs every failed `<img>`/`<video>`/`<audio>`/`<source>` URL to the Rust log (`[MediaErrorJS]`). Helps diagnose router ad-blocker CDN blocks without DevTools.

---

### Audit Fix A — Stale comment fragment removed
Orphaned "macOS vs Linux/Windows: • macOS WKWebView emits title=…" bullet (cut off mid-sentence) removed from the Phase K comment block.

### Audit Fix B — MEDIA_ERROR_LOGGER_SCRIPT capture comment accuracy
Corrected "catches errors from all descendant frames" → "catches errors from same-origin frames; cross-origin iframes excluded by browser SOP".

### Audit Fix C (critical) — page_load_stable good-title recovery
On WebKitGTK, SPA thread navigations may fire `on_navigation` (resetting `page_load_stable=false`) without a subsequent `on_page_load::Finished` — permanently disarming CrashDetect for the session. Added recovery in `on_document_title_changed`: when a good Messenger title is seen while `page_load_stable=false`, it is restored to `true` so CrashDetect remains operational.

### Audit Fix D — Regression test
`good_title_recovery_sets_page_load_stable_when_finished_not_received` asserts the recovery pattern exists in source. **85/85 tests pass** (up from 84 — 1 new test added).

---

## Checklist
- [x] `cargo test` — 85/85 green
- [x] `cargo clippy -- -D warnings` — clean
- [x] `npx tsc --noEmit` — clean
- [x] Two commits: `1ae11a6` (fixes 1–4) + `5318df3` (audit fixes A–D)