### PR TITLE
fix: suppress unused-variable warning on Linux; fix test-build workflow

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -93,6 +93,11 @@ jobs:
         run: |
           git fetch --tags --quiet 2>/dev/null || true
           LATEST_TAG=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          if [[ -z "$LATEST_TAG" ]]; then
+            echo "Error: no vX.Y.Z release tag found in repository — cannot determine base version for test build."
+            echo "Create at least one release tag (e.g. v0.1.0) before running the test-build workflow."
+            exit 1
+          fi
           BASE_VERSION="${LATEST_TAG#v}"
           # Append sanitized branch name as a semver pre-release identifier so
           # test artifacts are immediately distinguishable from production builds

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -93,8 +93,16 @@ jobs:
         run: |
           git fetch --tags --quiet 2>/dev/null || true
           LATEST_TAG=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
-          VERSION="${LATEST_TAG#v}"
-          echo "Latest release tag: ${LATEST_TAG} → version ${VERSION}"
+          BASE_VERSION="${LATEST_TAG#v}"
+          # Append sanitized branch name as a semver pre-release identifier so
+          # test artifacts are immediately distinguishable from production builds
+          # (e.g. 1.5.2-fix-release-warnings, 1.5.2-main).
+          SAFE_BRANCH=$(echo "${GITHUB_REF_NAME}" \
+            | sed 's/[^a-zA-Z0-9]/-/g' \
+            | sed 's/-\+/-/g'          \
+            | sed 's/^-//;s/-$//')
+          VERSION="${BASE_VERSION}-${SAFE_BRANCH}"
+          echo "Test build version: ${VERSION}  (base: ${BASE_VERSION}, branch: ${GITHUB_REF_NAME})"
           node -e "
             const fs = require('fs');
             const v = '${VERSION}';

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -37,6 +37,12 @@ jobs:
             rust-targets: 'aarch64-apple-darwin'
             label: 'macOS-arm64'
 
+          # ── macOS Intel ───────────────────────────────────────────────────
+          - platform: 'macos-latest'
+            args: '--target x86_64-apple-darwin'
+            rust-targets: 'x86_64-apple-darwin'
+            label: 'macOS-x64'
+
           # ── Windows x64 ───────────────────────────────────────────────────
           - platform: 'windows-latest'
             args: ''
@@ -54,6 +60,8 @@ jobs:
     steps:
       - name: Checkout branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-tags: true
 
       - name: Install Linux system dependencies
         if: contains(matrix.platform, 'ubuntu')
@@ -75,6 +83,36 @@ jobs:
         with:
           node-version: 'lts/*'
           cache: 'npm'
+
+      # Patch version files to match the latest release tag so debug
+      # artifacts carry a meaningful version instead of the stale value
+      # committed in the source tree.  Mirrors the "Sync source versions
+      # to release tag" step in release.yml (idempotent; safe to re-run).
+      - name: Sync source versions to latest release tag
+        shell: bash
+        run: |
+          git fetch --tags --quiet 2>/dev/null || true
+          LATEST_TAG=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          VERSION="${LATEST_TAG#v}"
+          echo "Latest release tag: ${LATEST_TAG} → version ${VERSION}"
+          node -e "
+            const fs = require('fs');
+            const v = '${VERSION}';
+
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            pkg.version = v;
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+
+            const tc = JSON.parse(fs.readFileSync('src-tauri/tauri.conf.json', 'utf8'));
+            tc.version = v;
+            fs.writeFileSync('src-tauri/tauri.conf.json', JSON.stringify(tc, null, 2) + '\n');
+
+            let cargo = fs.readFileSync('src-tauri/Cargo.toml', 'utf8');
+            cargo = cargo.replace(/^version = \"[^\"]*\"/m, 'version = \"' + v + '\"');
+            fs.writeFileSync('src-tauri/Cargo.toml', cargo);
+
+            console.log('All source versions set to ' + v);
+          "
 
       - name: Install Rust stable toolchain (Linux / macOS)
         if: runner.os != 'Windows'

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -92,20 +92,30 @@ jobs:
         shell: bash
         run: |
           git fetch --tags --quiet 2>/dev/null || true
-          LATEST_TAG=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          # Use grep -m 1 (stop after first match) instead of grep | head -1
+          # to avoid SIGPIPE causing a non-zero exit under pipefail. The || true
+          # guards against grep exiting 1 when no tag matches, ensuring the
+          # empty-tag check below always gets a chance to run.
+          LATEST_TAG=$(git tag --sort=-v:refname \
+            | grep -m 1 -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true)
           if [[ -z "$LATEST_TAG" ]]; then
             echo "Error: no vX.Y.Z release tag found in repository — cannot determine base version for test build."
             echo "Create at least one release tag (e.g. v0.1.0) before running the test-build workflow."
             exit 1
           fi
           BASE_VERSION="${LATEST_TAG#v}"
-          # Append sanitized branch name as a semver pre-release identifier so
-          # test artifacts are immediately distinguishable from production builds
-          # (e.g. 1.5.2-fix-release-warnings, 1.5.2-main).
+          # Sanitize branch name for use as a semver pre-release identifier.
+          # Replace non-alphanumeric chars with '-', collapse runs, strip
+          # leading/trailing dashes, then fall back to 'dev' if nothing remains.
+          # If the result starts with a digit, prefix with 'b' — semver allows
+          # numeric pre-release identifiers but forbids leading zeroes (e.g.
+          # branch '01' would produce '1.5.2-01' which Cargo rejects).
           SAFE_BRANCH=$(echo "${GITHUB_REF_NAME}" \
             | sed 's/[^a-zA-Z0-9]/-/g' \
-            | sed 's/-\+/-/g'          \
+            | sed -E 's/-+/-/g'         \
             | sed 's/^-//;s/-$//')
+          SAFE_BRANCH="${SAFE_BRANCH:-dev}"
+          [[ "$SAFE_BRANCH" =~ ^[0-9] ]] && SAFE_BRANCH="b${SAFE_BRANCH}"
           VERSION="${BASE_VERSION}-${SAFE_BRANCH}"
           echo "Test build version: ${VERSION}  (base: ${BASE_VERSION}, branch: ${GITHUB_REF_NAME})"
           node -e "

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messengerx",
-  "version": "1.5.2-fix-release-warnings",
+  "version": "1.5.2",
   "description": "Cross-platform Messenger desktop client (Tauri)",
   "private": true,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messengerx",
-  "version": "1.4.9",
+  "version": "1.5.2-fix-release-warnings",
   "description": "Cross-platform Messenger desktop client (Tauri)",
   "private": true,
   "type": "module",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "messengerx"
-version = "1.4.9"
+version = "1.5.2-fix-release-warnings"
 description = "Cross-platform Messenger desktop client (Tauri)"
 authors = ["lasakondrej"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "messengerx"
-version = "1.5.2-fix-release-warnings"
+version = "1.5.2"
 description = "Cross-platform Messenger desktop client (Tauri)"
 authors = ["lasakondrej"]
 license = "MIT"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6248,11 +6248,17 @@ mod tests {
 
         #[test]
         fn windows_startup_activation_runs_in_ready_event() {
+            // Assert a contiguous three-line snippet so the test cannot be
+            // satisfied by other RunEvent::Ready matches (e.g. the diagnostic
+            // log block that runs on all platforms) or by the Windows guard
+            // and Ready match existing independently in unrelated locations.
             assert!(
-                SOURCE.contains("if cfg!(target_os = \"windows\")")
-                    && SOURCE.contains("if let tauri::RunEvent::Ready = event"),
-                "Windows startup activation must remain in RunEvent::Ready, \
-                 guarded by if cfg!(target_os = \"windows\")"
+                SOURCE.contains(
+                    "if cfg!(target_os = \"windows\") {\n                if let tauri::RunEvent::Ready = event {\n                    if let Some(window) = app_handle.get_webview_window(\"main\")"
+                ),
+                "Windows startup activation must remain inside RunEvent::Ready, \
+                 guarded by if cfg!(target_os = \"windows\"), and must call \
+                 app_handle.get_webview_window(\"main\")"
             );
         }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3514,19 +3514,25 @@ pub fn run() {
             // startup foreground workaround after the runtime reports Ready,
             // but only for a window that setup has already decided should be
             // visible.
-            #[cfg(target_os = "windows")]
-            if let tauri::RunEvent::Ready = event {
-                if let Some(window) = app_handle.get_webview_window("main") {
-                    if matches!(window.is_visible(), Ok(true)) {
-                        let _ = window.show();
-                        let _ = window.unminimize();
-                        let _ = window.set_focus();
+            // Use if cfg!() instead of #[cfg()] so that app_handle is
+            // referenced on all platforms, avoiding an unused-variable warning
+            // on Linux where no cfg-gated block references it.
+            if cfg!(target_os = "windows") {
+                if let tauri::RunEvent::Ready = event {
+                    if let Some(window) = app_handle.get_webview_window("main") {
+                        if matches!(window.is_visible(), Ok(true)) {
+                            let _ = window.show();
+                            let _ = window.unminimize();
+                            let _ = window.set_focus();
+                        }
                     }
                 }
             }
 
             // macOS: clicking the Dock icon while all windows are hidden should
             // bring the main window back (applicationShouldHandleReopen).
+            // Must stay #[cfg()] — RunEvent::Reopen is a macOS-only enum
+            // variant that does not exist on other platforms.
             #[cfg(target_os = "macos")]
             if let tauri::RunEvent::Reopen {
                 has_visible_windows,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6249,9 +6249,10 @@ mod tests {
         #[test]
         fn windows_startup_activation_runs_in_ready_event() {
             assert!(
-                SOURCE.contains("#[cfg(target_os = \"windows\")]")
+                SOURCE.contains("if cfg!(target_os = \"windows\")")
                     && SOURCE.contains("if let tauri::RunEvent::Ready = event"),
-                "Windows startup activation must remain in RunEvent::Ready"
+                "Windows startup activation must remain in RunEvent::Ready, \
+                 guarded by if cfg!(target_os = \"windows\")"
             );
         }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Messenger X",
-  "version": "1.5.2-fix-release-warnings",
+  "version": "1.5.2",
   "identifier": "com.lasakondrej.messengerx",
   "build": {
     "frontendDist": "../src"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Messenger X",
-  "version": "1.4.9",
+  "version": "1.5.2-fix-release-warnings",
   "identifier": "com.lasakondrej.messengerx",
   "build": {
     "frontendDist": "../src"


### PR DESCRIPTION
## Changes

### 1. Rust: suppress unused `app_handle` warning on Linux (lib.rs)

On Linux, both `#[cfg(target_os = "windows")]` and `#[cfg(target_os = "macos")]` blocks inside the `.run()` closure are stripped, leaving `app_handle` unreferenced and triggering a compiler warning on every Linux x64 and arm64 build.

**Fix:** Convert the Windows block from `#[cfg(target_os = "windows")]` to `if cfg!(target_os = "windows")`. The code compiles on all platforms (dead path on non-Windows) so `app_handle` is referenced and the lint is satisfied. The macOS `Reopen` block must stay as `#[cfg()]` because `RunEvent::Reopen` is a macOS-only enum variant.

Regression test updated to assert a contiguous three-line snippet (Windows guard + Ready event + `get_webview_window`) so it cannot be satisfied by the all-platform diagnostic log block or by unrelated `#[cfg]` occurrences elsewhere.

### 2. CI: fix test-build workflow (test-build.yml)

Three issues corrected:

- **Missing platform:** Added **macOS-x64** (Intel) to the matrix — release.yml covers 6 platforms, test-build only covered 5.
- **Wrong version in artifacts:** Added a "Sync source versions to latest release tag" step (mirrors release.yml) that reads the highest `vX.Y.Z` tag and patches `package.json`, `tauri.conf.json`, and `Cargo.toml` before building. Added an explicit failure guard if no tag is found.
- **Unidentifiable artifacts:** Test build version now uses the format `{latest-tag}-{sanitized-branch}` (e.g. `1.5.2-fix-release-warnings`) so debug artifacts are immediately distinguishable from production builds. Source files on the branch are patched to match, so local `cargo build` / `cargo test` also show the correct version.

Also added `fetch-tags: true` to the checkout step so tags are available without an extra fetch.

## Verification

- `cargo clippy -- -D warnings` → clean, 0 warnings
- `cargo test` → 92 tests, 0 failures
- Test-build workflow: all 6 platforms ✅ (run [#26694798524](https://github.com/jimicze/fb-messenger-crossplatform/actions/runs/26694798524))