### PR TITLE
fix: time-rearm off, in-place badge clear, translocation guard, 2nd-sender detection

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -229,6 +229,15 @@ const TYPING_REARM_SECS: u64 = 5;
 /// indefinitely (production spam).  The cap resets on a genuine new message.
 const NOTIF_REARM_SECS: u64 = 60;
 
+/// Master switch for the time-based re-arm (`time_rearm`) feature.
+///
+/// **Temporarily disabled** (`false`) at the user's request: even with the
+/// cap-to-one-fire fix (`time_rearm_exhausted`), the 60-second reminder is
+/// undesirable in practice, so it is turned off completely for now.  The full
+/// `time_rearm` logic (and its regression tests) is left in place so it can be
+/// re-enabled by flipping this flag back to `true`.
+const TIME_REARM_ENABLED: bool = false;
+
 /// Grace period after a window restore-from-minimized during which a notification
 /// is fired even if `is_focused()` returns true.  Cinnamon/Muffin focuses the
 /// window instantly on un-iconify, so without this gate the user would see
@@ -407,7 +416,8 @@ fn decide_notification(
                 // `prev_time_exhausted`: without the cap a single unread message
                 // whose title oscillates re-fired every 60 s indefinitely (~85
                 // banners/85 min in production).
-                let time_rearm = elapsed >= NOTIF_REARM_SECS && !prev_time_exhausted;
+                let time_rearm =
+                    TIME_REARM_ENABLED && elapsed >= NOTIF_REARM_SECS && !prev_time_exhausted;
                 let should_fire = notifications_enabled
                     && !is_focused
                     && (count_increased || (sig_changed && !sig_under_floor) || time_rearm);
@@ -548,7 +558,9 @@ fn decide_notification(
                 // still hasn't read the message, fire ONE more reminder.  Capped
                 // per Notified entry via `prev_time_rearm_exhausted` so an
                 // oscillating title does not re-fire every 60 s forever.
-                let time_rearm = elapsed >= NOTIF_REARM_SECS && !prev_time_rearm_exhausted;
+                let time_rearm = TIME_REARM_ENABLED
+                    && elapsed >= NOTIF_REARM_SECS
+                    && !prev_time_rearm_exhausted;
                 let should_fire = notifications_enabled
                     && !is_focused
                     && (count_increased
@@ -1979,6 +1991,9 @@ mod tests {
     /// `typing-indicator-rearm` ~5 s later → 2 notifications/minute spam.
     #[test]
     fn test_typing_indicator_rearm_not_reset_by_time_rearm() {
+        if !TIME_REARM_ENABLED {
+            return; // time-rearm temporarily disabled — see TIME_REARM_ENABLED
+        }
         // T=100: initial notification fires → Notified{exhausted=false}.
         let mut state = NotifState::Idle;
         let d = decide_notification(&mut state, 1, "", false, true, false, 100);
@@ -2023,6 +2038,9 @@ mod tests {
     /// arrives.
     #[test]
     fn test_time_rearm_fires_only_once() {
+        if !TIME_REARM_ENABLED {
+            return; // time-rearm temporarily disabled — see TIME_REARM_ENABLED
+        }
         // T=100: message arrives → initial notification (Idle → Notified).
         let mut state = NotifState::Idle;
         let d = decide_notification(&mut state, 1, "", false, true, false, 100);
@@ -2050,6 +2068,9 @@ mod tests {
     /// so a brand-new message still gets its own single reminder.
     #[test]
     fn test_time_rearm_cap_reset_by_count_increase() {
+        if !TIME_REARM_ENABLED {
+            return; // time-rearm temporarily disabled — see TIME_REARM_ENABLED
+        }
         let mut state = NotifState::Idle;
         let d = decide_notification(&mut state, 1, "", false, true, false, 100);
         assert!(d.should_fire);
@@ -2079,6 +2100,9 @@ mod tests {
     /// then stay exhausted across subsequent zero-bounces.
     #[test]
     fn test_time_rearm_only_once_through_zero_bounce() {
+        if !TIME_REARM_ENABLED {
+            return; // time-rearm temporarily disabled — see TIME_REARM_ENABLED
+        }
         let mut state = NotifState::Idle;
         let d = decide_notification(&mut state, 1, "", false, true, false, 100);
         assert!(d.should_fire);
@@ -2304,6 +2328,9 @@ mod tests {
     /// After NOTIF_REARM_SECS with the same count the notification must re-fire.
     #[test]
     fn test_time_rearm_60s_fires_after_elapsed() {
+        if !TIME_REARM_ENABLED {
+            return; // time-rearm temporarily disabled — see TIME_REARM_ENABLED
+        }
         let mut state = NotifState::Notified {
             count: 1,
             sig: String::new(),
@@ -2349,6 +2376,9 @@ mod tests {
     /// immediate call must be suppressed (anti-spam guard).
     #[test]
     fn test_time_rearm_60s_resets_timer_after_fire() {
+        if !TIME_REARM_ENABLED {
+            return; // time-rearm temporarily disabled — see TIME_REARM_ENABLED
+        }
         let mut state = NotifState::Notified {
             count: 1,
             sig: String::new(),
@@ -2388,6 +2418,9 @@ mod tests {
     /// but a new message arrives 60 s after the original notification.
     #[test]
     fn test_time_rearm_60s_from_zero_pending_fires() {
+        if !TIME_REARM_ENABLED {
+            return; // time-rearm temporarily disabled — see TIME_REARM_ENABLED
+        }
         // Original notif fired at T=100, user read at T=103 (ZeroPending entered
         // via unfocused path to keep the test independent of fix 1).
         let mut state = NotifState::ZeroPending {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -488,9 +488,10 @@ const UNREAD_OBSERVER_SCRIPT: &str = r#"
     //
     // The latch remembers the title value at which we last reconciled down, so the
     // lowered value survives the window losing focus (otherwise an unfocus would
-    // re-raise the badge from the still-stale title).  A genuinely new message
-    // bumps the title beyond the latched value, which invalidates the latch and
-    // restores title-trust — so new-message notifications are never suppressed.
+    // re-raise the badge from the still-stale title).  A genuinely new message may
+    // NOT bump the title (Messenger's title count is per-open conversation), so a
+    // DOM unread count that rises above the reconciled value also invalidates the
+    // latch and restores notification delivery.
     // ---------------------------------------------------------------------------
     var reconciledTitleCount = -1; // title value when we last reconciled down
     var reconciledValue = -1;      // the lower (DOM-derived) value we pushed
@@ -516,7 +517,8 @@ const UNREAD_OBSERVER_SCRIPT: &str = r#"
         // regardless of focus (an unfocused new message must still notify; a
         // focused one updates the badge).  The latch is irrelevant when rising.
         if (domUnread > titleCount) {
-            clearReconcileLatch();
+            reconciledTitleCount = -1;
+            reconciledValue = -1;
             if (domUnread !== _lastMultiSenderDom) {
                 _lastMultiSenderDom = domUnread;
                 jlog('[MultiSender] title=' + titleCount + ' domUnread=' + domUnread
@@ -529,11 +531,21 @@ const UNREAD_OBSERVER_SCRIPT: &str = r#"
             clearReconcileLatch();
             return titleCount;
         }
-        // Honour an active latch while the title has not grown past it (no new
-        // message): keep showing the reconciled-down value even when unfocused.
+        // Honour an active latch only while the DOM has NOT risen above the
+        // reconciled-down value.  This covers the real-world edge case:
+        // title stays stale at "(1)", user reads active chat in-place → latch=0,
+        // then Bob sends a new unread thread and DOM rises back to 1 while title
+        // still equals the latched title.  Returning the latched 0 there would
+        // suppress Bob forever; DOM rise must invalidate the latch.
         if (reconciledTitleCount === titleCount
                 && reconciledValue >= 0
                 && reconciledValue < titleCount) {
+            if (domUnread >= 0 && domUnread > reconciledValue) {
+                clearReconcileLatch();
+                jlog('[ReadInPlace] latch invalidated by DOM rise title=' + titleCount
+                    + ' domUnread=' + domUnread + ' reconciled=' + reconciledValue);
+                return Math.max(titleCount, domUnread);
+            }
             return reconciledValue;
         }
         var focused = false;
@@ -652,6 +664,48 @@ const UNREAD_OBSERVER_SCRIPT: &str = r#"
     }
 
     // ---------------------------------------------------------------------------
+    // Resolve the conversation-list root.  The unread counter must scan the
+    // sidebar/list, not the whole document: broad `[role="link"][tabindex]`
+    // matches unrelated controls in the active thread and can create false
+    // unread counts.  Prefer semantic Messenger roots, then infer a shared
+    // ancestor from thread href links.  Return null when no trusted list root
+    // exists; callers then treat the DOM count as unknown (-1).
+    function getConversationListRoot() {
+        var anyThreadLink = 'a[href*="/t/"], a[href*="/e2ee/"], a[href*="thread_fbid"], [role="link"][tabindex]';
+        var hrefThreadLink = 'a[href*="/t/"], a[href*="/e2ee/"], a[href*="thread_fbid"]';
+        try {
+            var roots = document.querySelectorAll(
+                '[role="navigation"], [role="complementary"], nav, '
+                + '[aria-label*="Chats"], [aria-label*="Chaty"], [aria-label*="Konverzace"]'
+            );
+            for (var ri = 0; ri < roots.length; ri++) {
+                if (roots[ri] && roots[ri].querySelector(anyThreadLink)) {
+                    return roots[ri];
+                }
+            }
+
+            // Some Messenger builds expose no semantic navigation root.  Infer a
+            // scoped root from real thread hrefs (not broad role links) by walking
+            // up until an ancestor contains the visible thread-link cluster.  Never
+            // return document.body; body-scope is exactly what causes false counts.
+            var hrefLinks = document.querySelectorAll(hrefThreadLink);
+            for (var li = 0; li < hrefLinks.length; li++) {
+                var node = hrefLinks[li].parentElement;
+                for (var depth = 0; depth < 10 && node && node !== document.body; depth++) {
+                    var count = node.querySelectorAll(hrefThreadLink).length;
+                    if (count >= Math.min(2, hrefLinks.length)) {
+                        return node;
+                    }
+                    node = node.parentElement;
+                }
+            }
+            if (hrefLinks.length === 1) {
+                return hrefLinks[0].parentElement || hrefLinks[0];
+            }
+        } catch(_) {}
+        return null;
+    }
+
     // getAllThreadLinks() — expanded link selector that covers all thread URL patterns.
     // De-duplicated by href to avoid processing the same link multiple times.
     // Used in getActivitySnapshot() and getFirstUnreadSenderName().
@@ -659,6 +713,8 @@ const UNREAD_OBSERVER_SCRIPT: &str = r#"
     function getAllThreadLinks() {
         var seen = {};
         var result = [];
+        var root = getConversationListRoot();
+        if (!root) return result;
         var selectors = [
             'a[href*="/t/"]',
             'a[href*="/e2ee/"]',
@@ -667,10 +723,22 @@ const UNREAD_OBSERVER_SCRIPT: &str = r#"
         ];
         for (var si = 0; si < selectors.length; si++) {
             try {
-                var nodes = document.querySelectorAll(selectors[si]);
+                var nodes = root.querySelectorAll(selectors[si]);
                 for (var ni = 0; ni < nodes.length; ni++) {
                     var node = nodes[ni];
-                    var key = (node.getAttribute('href') || '') + '||' + (node.getAttribute('data-key') || ni);
+                    var href = node.getAttribute('href') || '';
+                    var dataKey = node.getAttribute('data-key') || '';
+                    var aria = node.getAttribute('aria-label') || '';
+                    var text = (node.textContent || '').replace(/\s+/g, ' ').trim().slice(0, 120);
+                    // Prefer stable conversation identifiers.  Do NOT append the
+                    // loop index to href: the same anchor can match multiple
+                    // selectors (`/t/` + `[role="link"][tabindex]`) and would be
+                    // counted twice, inflating domUnread and causing false badges.
+                    var key = href ? ('href:' + href)
+                        : dataKey ? ('data:' + dataKey)
+                        : aria ? ('aria:' + aria)
+                        : text ? ('text:' + text)
+                        : ('idx:' + si + ':' + ni);
                     if (!seen[key]) {
                         seen[key] = true;
                         result.push(node);
@@ -1196,7 +1264,7 @@ const UNREAD_OBSERVER_SCRIPT: &str = r#"
             _threadMutDebounceTimer = null;
             var batch = _pendingThreadMutations;
             _pendingThreadMutations = [];
-            var currentCount = getUnreadCountFromTitle();
+            var currentCount = effectiveUnreadCount();
             jlog('[ThreadMut] batch size=' + batch.length + ' source=' + fromSource + ' count=' + currentCount);
             var bumped = tryBumpThreadMutSeq(batch, currentCount);
             if (bumped) {
@@ -6908,9 +6976,11 @@ mod tests {
             );
         }
 
-        /// The DOM count must only be trusted when the window is focused and the
+        /// A LOWER DOM count is only trusted when the window is focused and the
         /// conversation list is present (returns -1 / unknown when absent), so a
         /// brand-new message while unfocused still notifies via the title count.
+        /// A HIGHER DOM count is trusted regardless of focus for the multi-sender
+        /// case covered below.
         #[test]
         fn dom_reconciliation_is_focus_gated_and_list_guarded() {
             assert!(
@@ -6925,7 +6995,8 @@ mod tests {
 
         /// The reconciliation latch must survive the window losing focus (so the
         /// badge does not re-raise from the still-stale title) yet yield to a
-        /// genuinely new message that bumps the title past the latched value.
+        /// genuinely new message detected by DOM unread-count rise even when the
+        /// stale title does NOT change.
         #[test]
         fn latch_survives_unfocus_but_yields_to_new_message() {
             assert!(
@@ -6935,6 +7006,10 @@ mod tests {
             assert!(
                 UNREAD_OBSERVER_SCRIPT.contains("function clearReconcileLatch"),
                 "script must define clearReconcileLatch to invalidate the latch"
+            );
+            assert!(
+                UNREAD_OBSERVER_SCRIPT.contains("domUnread >= 0 && domUnread > reconciledValue"),
+                "latch must be invalidated when DOM unread count rises above the reconciled value"
             );
         }
 
@@ -6977,8 +7052,46 @@ mod tests {
                 "MultiSender diagnostic must only fire when domUnread changes"
             );
             assert!(
-                UNREAD_OBSERVER_SCRIPT.contains("_lastMultiSenderDom = -1"),
-                "clearReconcileLatch must reset the MultiSender throttle so it can re-fire"
+                !UNREAD_OBSERVER_SCRIPT.contains("if (domUnread > titleCount) {\n            clearReconcileLatch();"),
+                "MultiSender branch must not reset the throttle before checking it"
+            );
+        }
+
+        /// DOM unread scans must be scoped to a conversation-list root, not the
+        /// entire document/body.  Otherwise broad role-link selectors can count
+        /// unrelated controls in the active thread as unread conversations.
+        #[test]
+        fn thread_link_scan_is_scoped_to_conversation_list_root() {
+            assert!(
+                UNREAD_OBSERVER_SCRIPT.contains("function getConversationListRoot"),
+                "script must resolve a trusted conversation-list root"
+            );
+            assert!(
+                UNREAD_OBSERVER_SCRIPT.contains("var root = getConversationListRoot();"),
+                "getAllThreadLinks must query inside the resolved root"
+            );
+            assert!(
+                UNREAD_OBSERVER_SCRIPT.contains("var nodes = root.querySelectorAll(selectors[si]);"),
+                "thread-link selectors must be scoped to the root, not document"
+            );
+            assert!(
+                UNREAD_OBSERVER_SCRIPT.contains("var key = href ? ('href:' + href)"),
+                "thread links must de-duplicate by stable href/data/aria/text identity"
+            );
+            assert!(
+                !UNREAD_OBSERVER_SCRIPT.contains("(node.getAttribute('data-key') || ni)"),
+                "thread links must not append loop index to href/data-key because duplicate selector matches inflate domUnread"
+            );
+        }
+
+        /// Thread/body mutation batches must use the same effective count as the
+        /// polling path; otherwise title=0/stale cases still fail to bump the
+        /// mutation sequence and activity_sig remains unchanged.
+        #[test]
+        fn thread_mutation_path_uses_effective_count() {
+            assert!(
+                UNREAD_OBSERVER_SCRIPT.contains("var currentCount = effectiveUnreadCount();\n            jlog('[ThreadMut]"),
+                "thread mutation batching must use effectiveUnreadCount before tryBumpThreadMutSeq"
             );
         }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -496,9 +496,13 @@ const UNREAD_OBSERVER_SCRIPT: &str = r#"
     var reconciledTitleCount = -1; // title value when we last reconciled down
     var reconciledValue = -1;      // the lower (DOM-derived) value we pushed
 
-    function clearReconcileLatch() {
+    function clearLatchOnly() {
         reconciledTitleCount = -1;
         reconciledValue = -1;
+    }
+
+    function clearReconcileLatch() {
+        clearLatchOnly();
         _lastMultiSenderDom = -1;
     }
 
@@ -517,8 +521,9 @@ const UNREAD_OBSERVER_SCRIPT: &str = r#"
         // regardless of focus (an unfocused new message must still notify; a
         // focused one updates the badge).  The latch is irrelevant when rising.
         if (domUnread > titleCount) {
-            reconciledTitleCount = -1;
-            reconciledValue = -1;
+            // Clear only the read-in-place latch; keep _lastMultiSenderDom so
+            // repeated 2 s polls do not spam identical [MultiSender] lines.
+            clearLatchOnly();
             if (domUnread !== _lastMultiSenderDom) {
                 _lastMultiSenderDom = domUnread;
                 jlog('[MultiSender] title=' + titleCount + ' domUnread=' + domUnread
@@ -689,12 +694,41 @@ const UNREAD_OBSERVER_SCRIPT: &str = r#"
             }
             return n;
         }
+
+        // Locale-aware but still conservative: explicitly chat-labeled roots may
+        // use broad role-link rows because some Messenger builds omit hrefs.  The
+        // generic navigation/complementary fallback below still requires real
+        // thread hrefs to avoid counting unrelated controls.
+        function isChatListLabel(label) {
+            var l = (label || '').toLowerCase();
+            var keys = [
+                // English, Czech/Slovak, German, French, Spanish, Italian,
+                // Portuguese, Polish, Dutch, Romanian, Hungarian, Russian,
+                // Ukrainian, Croatian/Serbian/Bosnian, Slovenian, Turkish.
+                'chat','konverz','zpr\u00e1v','spr\u00e1v','unterhaltung','nachricht',
+                'discussion','message','mensaje','conversaci','chatta','messagg',
+                'conversa','czat','wiadomo','gesprek','bericht','conversa\u021b',
+                'mesaj','\u00fczenet','besz\u00e9lget','\u0447\u0430\u0442','\u0441\u043e\u043e\u0431\u0449',
+                '\u043f\u043e\u0432\u0456\u0434','razgovor','poruk','sporo\u010d','sohbet'
+            ];
+            for (var ki = 0; ki < keys.length; ki++) {
+                if (l.indexOf(keys[ki]) !== -1) return true;
+            }
+            return false;
+        }
+
         try {
-            var chatRoots = document.querySelectorAll(
-                '[aria-label*="Chats"], [aria-label*="Chaty"], [aria-label*="Konverzace"]'
-            );
+            var chatRoots = document.querySelectorAll('[aria-label], [aria-labelledby]');
             for (var ci = 0; ci < chatRoots.length; ci++) {
-                if (chatRoots[ci] && chatRoots[ci].querySelector(anyThreadLink)) {
+                var label = chatRoots[ci].getAttribute('aria-label') || '';
+                var labelledBy = chatRoots[ci].getAttribute('aria-labelledby') || '';
+                if (labelledBy) {
+                    try {
+                        var labelEl = document.getElementById(labelledBy);
+                        if (labelEl) label += ' ' + (labelEl.textContent || '');
+                    } catch(_) {}
+                }
+                if (chatRoots[ci] && isChatListLabel(label) && chatRoots[ci].querySelector(anyThreadLink)) {
                     return chatRoots[ci];
                 }
             }
@@ -792,7 +826,7 @@ const UNREAD_OBSERVER_SCRIPT: &str = r#"
     //
     // PERFORMANCE NOTE: this walks every sidebar thread link and calls
     // getComputedStyle per span — it forces layout.  Called every 2 s via the
-    // poll when effectiveUnreadCount is invoked.  The early return above
+    // poll when effectiveUnreadCount is invoked.  The early return below
     // (links.length === 0) keeps the idle cost near-zero when the list is not in
     // the DOM; when the list is present the cost is proportional to the number
     // of visible conversations (~20–30 on a typical screen).  If jank is observed
@@ -7085,6 +7119,14 @@ mod tests {
                 !UNREAD_OBSERVER_SCRIPT.contains("if (domUnread > titleCount) {\n            clearReconcileLatch();"),
                 "MultiSender branch must not reset the throttle before checking it"
             );
+            assert!(
+                UNREAD_OBSERVER_SCRIPT.contains("function clearLatchOnly"),
+                "latch-only reset helper must keep throttle-safe reset logic in one place"
+            );
+            assert!(
+                UNREAD_OBSERVER_SCRIPT.contains("clearLatchOnly();\n            if (domUnread !== _lastMultiSenderDom)"),
+                "MultiSender branch must clear only the latch before throttle check"
+            );
         }
 
         /// DOM unread scans must be scoped to a conversation-list root, not the
@@ -7107,6 +7149,16 @@ mod tests {
             assert!(
                 UNREAD_OBSERVER_SCRIPT.contains("distinctHrefCount(roots[ri]) > 0"),
                 "generic semantic roots must require real thread hrefs, not broad role links"
+            );
+            assert!(
+                UNREAD_OBSERVER_SCRIPT.contains("function isChatListLabel"),
+                "chat-list root detection must be locale-aware instead of hard-coding only English/Czech selectors"
+            );
+            assert!(
+                UNREAD_OBSERVER_SCRIPT.contains("discussion")
+                    && UNREAD_OBSERVER_SCRIPT.contains("conversa")
+                    && UNREAD_OBSERVER_SCRIPT.contains("czat"),
+                "chat-list root detection should cover common Messenger locales"
             );
             assert!(
                 UNREAD_OBSERVER_SCRIPT.contains("var nodes = root.querySelectorAll(selectors[si]);"),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -541,10 +541,13 @@ const UNREAD_OBSERVER_SCRIPT: &str = r#"
                 && reconciledValue >= 0
                 && reconciledValue < titleCount) {
             if (domUnread >= 0 && domUnread > reconciledValue) {
+                var oldReconciledValue = reconciledValue;
                 clearReconcileLatch();
                 jlog('[ReadInPlace] latch invalidated by DOM rise title=' + titleCount
-                    + ' domUnread=' + domUnread + ' reconciled=' + reconciledValue);
-                return Math.max(titleCount, domUnread);
+                    + ' domUnread=' + domUnread + ' reconciled=' + oldReconciledValue);
+                // The title was already proven stale by the latch; when DOM rises,
+                // trust the DOM count instead of re-trusting the stale title.
+                return domUnread;
             }
             return reconciledValue;
         }
@@ -673,13 +676,35 @@ const UNREAD_OBSERVER_SCRIPT: &str = r#"
     function getConversationListRoot() {
         var anyThreadLink = 'a[href*="/t/"], a[href*="/e2ee/"], a[href*="thread_fbid"], [role="link"][tabindex]';
         var hrefThreadLink = 'a[href*="/t/"], a[href*="/e2ee/"], a[href*="thread_fbid"]';
+        function distinctHrefCount(scope) {
+            var seenHref = {};
+            var links = scope.querySelectorAll(hrefThreadLink);
+            for (var hi = 0; hi < links.length; hi++) {
+                var href = links[hi].getAttribute('href') || '';
+                if (href.length > 0) seenHref[href] = true;
+            }
+            var n = 0;
+            for (var k in seenHref) {
+                if (Object.prototype.hasOwnProperty.call(seenHref, k)) n++;
+            }
+            return n;
+        }
         try {
-            var roots = document.querySelectorAll(
-                '[role="navigation"], [role="complementary"], nav, '
-                + '[aria-label*="Chats"], [aria-label*="Chaty"], [aria-label*="Konverzace"]'
+            var chatRoots = document.querySelectorAll(
+                '[aria-label*="Chats"], [aria-label*="Chaty"], [aria-label*="Konverzace"]'
             );
+            for (var ci = 0; ci < chatRoots.length; ci++) {
+                if (chatRoots[ci] && chatRoots[ci].querySelector(anyThreadLink)) {
+                    return chatRoots[ci];
+                }
+            }
+
+            var roots = document.querySelectorAll('[role="navigation"], [role="complementary"], nav');
             for (var ri = 0; ri < roots.length; ri++) {
-                if (roots[ri] && roots[ri].querySelector(anyThreadLink)) {
+                // Require real thread hrefs for generic semantic roots.  Broad
+                // role links inside navigation/complementary can be unrelated
+                // controls; allowing them here reintroduces false unread counts.
+                if (roots[ri] && distinctHrefCount(roots[ri]) > 0) {
                     return roots[ri];
                 }
             }
@@ -689,11 +714,12 @@ const UNREAD_OBSERVER_SCRIPT: &str = r#"
             // up until an ancestor contains the visible thread-link cluster.  Never
             // return document.body; body-scope is exactly what causes false counts.
             var hrefLinks = document.querySelectorAll(hrefThreadLink);
+            var totalDistinctHrefs = distinctHrefCount(document);
             for (var li = 0; li < hrefLinks.length; li++) {
                 var node = hrefLinks[li].parentElement;
                 for (var depth = 0; depth < 10 && node && node !== document.body; depth++) {
-                    var count = node.querySelectorAll(hrefThreadLink).length;
-                    if (count >= Math.min(2, hrefLinks.length)) {
+                    var count = distinctHrefCount(node);
+                    if (count >= Math.min(2, totalDistinctHrefs)) {
                         return node;
                     }
                     node = node.parentElement;
@@ -7011,6 +7037,10 @@ mod tests {
                 UNREAD_OBSERVER_SCRIPT.contains("domUnread >= 0 && domUnread > reconciledValue"),
                 "latch must be invalidated when DOM unread count rises above the reconciled value"
             );
+            assert!(
+                UNREAD_OBSERVER_SCRIPT.contains("return domUnread;"),
+                "latch invalidation must trust DOM count instead of stale title count"
+            );
         }
 
         /// `resetActivityState()` must NOT clear the latch while the title still
@@ -7069,6 +7099,14 @@ mod tests {
             assert!(
                 UNREAD_OBSERVER_SCRIPT.contains("var root = getConversationListRoot();"),
                 "getAllThreadLinks must query inside the resolved root"
+            );
+            assert!(
+                UNREAD_OBSERVER_SCRIPT.contains("function distinctHrefCount"),
+                "conversation-list root inference must count distinct thread href identities"
+            );
+            assert!(
+                UNREAD_OBSERVER_SCRIPT.contains("distinctHrefCount(roots[ri]) > 0"),
+                "generic semantic roots must require real thread hrefs, not broad role links"
             );
             assert!(
                 UNREAD_OBSERVER_SCRIPT.contains("var nodes = root.querySelectorAll(selectors[si]);"),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -478,6 +478,65 @@ const UNREAD_OBSERVER_SCRIPT: &str = r#"
     }
 
     // ---------------------------------------------------------------------------
+    // Read-in-place reconciliation latch.
+    //
+    // Messenger keeps the `(N)` title prefix after the user reads the active
+    // conversation in-place (it only rewrites the title on navigation).  When the
+    // window is focused we cross-check the title against the sidebar DOM
+    // (`countUnreadThreadsFromDom`) and, if the DOM shows fewer unread threads,
+    // use the lower DOM value so the badge clears without a conversation switch.
+    //
+    // The latch remembers the title value at which we last reconciled down, so the
+    // lowered value survives the window losing focus (otherwise an unfocus would
+    // re-raise the badge from the still-stale title).  A genuinely new message
+    // bumps the title beyond the latched value, which invalidates the latch and
+    // restores title-trust — so new-message notifications are never suppressed.
+    // ---------------------------------------------------------------------------
+    var reconciledTitleCount = -1; // title value when we last reconciled down
+    var reconciledValue = -1;      // the lower (DOM-derived) value we pushed
+
+    function clearReconcileLatch() {
+        reconciledTitleCount = -1;
+        reconciledValue = -1;
+    }
+
+    function effectiveUnreadCount() {
+        var titleCount = getUnreadCountFromTitle();
+        if (titleCount <= 0) {
+            clearReconcileLatch();
+            return titleCount;
+        }
+        // Honour an active latch while the title has not grown past it (no new
+        // message): keep showing the reconciled-down value even when unfocused.
+        if (reconciledTitleCount === titleCount
+                && reconciledValue >= 0
+                && reconciledValue < titleCount) {
+            return reconciledValue;
+        }
+        var focused = false;
+        try { focused = typeof document.hasFocus === 'function' && document.hasFocus(); } catch(_) {}
+        if (!focused) {
+            // Unfocused + no active latch → trust the title so a brand-new message
+            // (DOM may not have rendered its unread marker yet) still notifies.
+            return titleCount;
+        }
+        var domUnread = countUnreadThreadsFromDom();
+        if (domUnread < 0) {
+            return titleCount; // conversation list absent — cannot trust DOM
+        }
+        if (domUnread < titleCount) {
+            reconciledTitleCount = titleCount;
+            reconciledValue = domUnread;
+            jlog('[ReadInPlace] focused; title=' + titleCount
+                + ' domUnread=' + domUnread + ' — reconciling badge to DOM count');
+            return domUnread;
+        }
+        clearReconcileLatch();
+        return titleCount;
+    }
+
+
+    // ---------------------------------------------------------------------------
     // Composite unread-signal detection for a single link element.
     // Returns an object: { isUnread: bool, hasBadge: bool, hasBold: bool, hasDot: bool }
     // ---------------------------------------------------------------------------
@@ -601,7 +660,36 @@ const UNREAD_OBSERVER_SCRIPT: &str = r#"
     }
 
     // ---------------------------------------------------------------------------
-    // Sender lookup — only returns a name when a confirmed unread signal exists.
+    // countUnreadThreadsFromDom() — count conversation threads that still show an
+    // unread signal in the sidebar DOM.
+    //
+    // Why: Messenger keeps the `(N)` prefix in document.title even after the user
+    // reads the active conversation *in-place* (it only rewrites the title on
+    // navigation / conversation switch).  The sidebar DOM, however, drops the
+    // unread markers (bold / badge / dot) for a thread as soon as it is read.
+    // Counting unread thread links therefore reflects the real unread state sooner
+    // than the title does, letting the badge clear without a conversation switch.
+    //
+    // Returns -1 ("unknown") when the conversation list is not present in the DOM
+    // (e.g. a narrow/thread-only view) so callers never clear a badge based on an
+    // absent list.  Otherwise returns the number of unread thread links.
+    // ---------------------------------------------------------------------------
+    function countUnreadThreadsFromDom() {
+        try {
+            var links = getAllThreadLinks();
+            if (links.length === 0) return -1; // list not in DOM — cannot determine
+            var n = 0;
+            for (var i = 0; i < links.length; i++) {
+                try {
+                    if (detectUnreadSignals(links[i]).isUnread) n++;
+                } catch(_) {}
+            }
+            return n;
+        } catch(_) {
+            return -1;
+        }
+    }
+
     // Does NOT fall back to the first conversation; that risks wrong sender name.
     // Uses expanded link selectors via getAllThreadLinks().
     // ---------------------------------------------------------------------------
@@ -958,6 +1046,15 @@ const UNREAD_OBSERVER_SCRIPT: &str = r#"
         lastThreadMutSeqAt = 0;
         _threadDiagSampleCount = 0;
         _threadDiagLastTs = 0;
+        // Only drop the read-in-place latch when the title itself has returned to
+        // 0.  If the title still shows "(N)" (Messenger keeps the prefix after an
+        // in-place read until navigation), clearing the latch here would let the
+        // next unfocused poll re-raise the badge from the stale title — exactly
+        // the bug the latch prevents.  When the title is genuinely 0 the latch is
+        // a no-op anyway (effectiveUnreadCount clears it on titleCount<=0).
+        if (getUnreadCountFromTitle() <= 0) {
+            clearReconcileLatch();
+        }
         if (activityDebounceTimer !== null) {
             clearTimeout(activityDebounceTimer);
             activityDebounceTimer = null;
@@ -1321,7 +1418,7 @@ const UNREAD_OBSERVER_SCRIPT: &str = r#"
         var prevLastSentSig = lastSentSig;
         lastSentSig = optimisticSig;
         setTimeout(function() {
-            var currentCount = getUnreadCountFromTitle();
+            var currentCount = effectiveUnreadCount();
             if (currentCount === 0) {
                 // Count dropped — revert optimistic sig so next real event fires.
                 lastSentSig = prevLastSentSig;
@@ -1350,14 +1447,14 @@ const UNREAD_OBSERVER_SCRIPT: &str = r#"
     }
 
     function setupObserver() {
-        var lastCount = getUnreadCountFromTitle();
-        prevTitleCount = lastCount;
+        var lastCount = effectiveUnreadCount();
+        prevTitleCount = getUnreadCountFromTitle();
         sendUnreadCount(lastCount);
         setupActivityObserver();
         var titleElement = document.querySelector('title');
         if (titleElement) {
             var observer = new MutationObserver(function() {
-                var newCount = getUnreadCountFromTitle();
+                var newCount = effectiveUnreadCount();
                 if (newCount !== lastCount) {
                     // Track rising edge BEFORE updating lastCount.
                     markRisingEdge(newCount);
@@ -1367,9 +1464,11 @@ const UNREAD_OBSERVER_SCRIPT: &str = r#"
             });
             observer.observe(titleElement, { childList: true, characterData: true, subtree: true });
         }
-        // Polling fallback: also catches sig changes (new message, same count).
+        // Polling fallback: also catches sig changes (new message, same count) and
+        // read-in-place reconciliation (title keeps `(N)` until navigation, but the
+        // sidebar DOM clears the unread marker — effectiveUnreadCount() picks that up).
         setInterval(function() {
-            var newCount = getUnreadCountFromTitle();
+            var newCount = effectiveUnreadCount();
             if (newCount > 0) {
                 refreshActivitySnapshot();
             }
@@ -1381,10 +1480,17 @@ const UNREAD_OBSERVER_SCRIPT: &str = r#"
             }
         }, 2000);
 
-        // When window gains focus and count=0, immediately reset baseline so
-        // the next new message starts fresh.
+        // When the window gains focus, recompute the effective count immediately:
+        //  - an in-place read performed while unfocused is reconciled to the lower
+        //    DOM count without waiting for the 2 s poll, and
+        //  - a count=0 result resets the activity baseline (user has seen messages).
         window.addEventListener('focus', function() {
-            var fc = getUnreadCountFromTitle();
+            var fc = effectiveUnreadCount();
+            if (fc !== lastCount) {
+                markRisingEdge(fc);
+                lastCount = fc;
+                sendUnreadCount(fc);
+            }
             if (fc === 0 && (lastActivitySnapshot.length > 0 || zeroTimer !== null)) {
                 jlog('[Activity] window focused with count=0 — resetting baseline');
                 resetActivityState();
@@ -3364,6 +3470,25 @@ where
 /// Number of days of rotated log archives to retain on disk.
 const LOG_RETENTION_DAYS: u64 = 7;
 
+/// Decide whether an executable path indicates the app is running under macOS
+/// **App Translocation** (Gatekeeper path randomization).
+///
+/// When an ad-hoc-signed / un-notarized `.app` carries the `com.apple.quarantine`
+/// xattr (set automatically when a CI artifact is downloaded via a browser),
+/// Gatekeeper executes it from an ephemeral read-only mount such as
+/// `/private/var/folders/<…>/AppTranslocation/<UUID>/d/Messenger X.app`. In that
+/// mode the persistent log file is not created in `~/Library/Logs/<id>/` and
+/// native notifications do not deliver reliably — making the build appear
+/// completely broken even though the process is running. Detecting the
+/// `/AppTranslocation/` segment lets us warn the tester to dequarantine
+/// (`xattr -dr com.apple.quarantine "/Applications/Messenger X.app"`).
+///
+/// Pure helper so the path policy can be unit-tested without a real bundle.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn is_translocated_path(exe_path: &str) -> bool {
+    exe_path.contains("/AppTranslocation/")
+}
+
 /// Decide whether a file in the log directory is a prunable rotated archive.
 ///
 /// `tauri-plugin-log`'s `KeepAll` rotation renames the active file to
@@ -3384,7 +3509,7 @@ fn is_prunable_archived_log(
     // next character is `_` (the separator used by tauri-plugin-log KeepAll).
     file_name
         .strip_prefix(prefix)
-        .map_or(false, |rest| rest.starts_with('_'))
+        .is_some_and(|rest| rest.starts_with('_'))
         && age_secs > max_age_secs
 }
 
@@ -3706,6 +3831,39 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     // is initialized (inside setup_app), not from run() where the logger is not yet
     // active. This was the bug that caused all [Env] lines to be silently dropped.
     log_platform_environment();
+
+    // macOS App Translocation guard.  A downloaded, ad-hoc-signed / un-notarized
+    // build carries `com.apple.quarantine`, so Gatekeeper runs it from an
+    // ephemeral `/AppTranslocation/<UUID>/…` mount where the log file is never
+    // written and native notifications do not deliver — the app appears broken
+    // for no visible reason.  Detect it, log a prominent warning, and show a
+    // one-time dialog telling the tester how to fix it.  No-op on Linux/Windows
+    // (those platforms have no translocation) and for properly installed builds.
+    #[cfg(target_os = "macos")]
+    {
+        let exe_path = std::env::current_exe()
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        if is_translocated_path(&exe_path) {
+            log::warn!(
+                "[MessengerX][Translocation] running translocated from {exe_path:?} — \
+                 logs and notifications WILL NOT work. Remove the quarantine attribute: \
+                 xattr -dr com.apple.quarantine \"/Applications/Messenger X.app\""
+            );
+            use tauri_plugin_dialog::DialogExt;
+            app.handle()
+                .dialog()
+                .message(
+                    "Aplikace běží v režimu macOS App Translocation (kvůli karanténě \
+                     u staženého buildu), takže notifikace ani logy nefungují.\n\n\
+                     Oprava: ukonči aplikaci a spusť v Terminálu:\n\
+                     xattr -dr com.apple.quarantine \"/Applications/Messenger X.app\"\n\n\
+                     Poté aplikaci spusť znovu.",
+                )
+                .title("Messenger X — akce potřebná")
+                .show(|_| {});
+        }
+    }
 
     // Prune rotated log archives older than the retention window. Runs once at
     // startup; failures are logged and ignored so this never blocks boot.
@@ -6402,6 +6560,36 @@ mod tests {
         }
     }
 
+    mod translocation {
+        use super::super::is_translocated_path;
+
+        #[test]
+        fn translocated_path_is_detected() {
+            assert!(is_translocated_path(
+                "/private/var/folders/cd/abc123/d/AppTranslocation/1234-UUID/d/Messenger X.app/Contents/MacOS/messengerx"
+            ));
+        }
+
+        #[test]
+        fn real_applications_path_is_not_translocated() {
+            assert!(!is_translocated_path(
+                "/Applications/Messenger X.app/Contents/MacOS/messengerx"
+            ));
+        }
+
+        #[test]
+        fn local_debug_build_path_is_not_translocated() {
+            assert!(!is_translocated_path(
+                "/Users/dev/project/src-tauri/target/debug/bundle/macos/Messenger X.app/Contents/MacOS/messengerx"
+            ));
+        }
+
+        #[test]
+        fn empty_path_is_not_translocated() {
+            assert!(!is_translocated_path(""));
+        }
+    }
+
     mod sender_hint_cache {
         use super::super::{SenderHintCache, SENDER_HINT_RETAIN};
         use std::time::{Duration, Instant};
@@ -6659,6 +6847,71 @@ mod tests {
             assert!(
                 VISIBILITY_OVERRIDE_SCRIPT.contains("get_window_focused"),
                 "script must invoke get_window_focused to resync state on each navigation"
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Unread observer — read-in-place badge reconciliation regression tests
+    // -----------------------------------------------------------------------
+    mod unread_read_in_place {
+        use super::super::UNREAD_OBSERVER_SCRIPT;
+
+        /// The script must derive an unread count from the sidebar DOM so an
+        /// in-place read can clear the badge even though Messenger keeps the
+        /// `(N)` document.title prefix until the user navigates.
+        #[test]
+        fn counts_unread_threads_from_dom() {
+            assert!(
+                UNREAD_OBSERVER_SCRIPT.contains("function countUnreadThreadsFromDom"),
+                "script must define countUnreadThreadsFromDom"
+            );
+            assert!(
+                UNREAD_OBSERVER_SCRIPT.contains("function effectiveUnreadCount"),
+                "script must define effectiveUnreadCount that reconciles title vs DOM"
+            );
+        }
+
+        /// The DOM count must only be trusted when the window is focused and the
+        /// conversation list is present (returns -1 / unknown when absent), so a
+        /// brand-new message while unfocused still notifies via the title count.
+        #[test]
+        fn dom_reconciliation_is_focus_gated_and_list_guarded() {
+            assert!(
+                UNREAD_OBSERVER_SCRIPT.contains("if (links.length === 0) return -1"),
+                "countUnreadThreadsFromDom must return -1 when the list is absent"
+            );
+            assert!(
+                UNREAD_OBSERVER_SCRIPT.contains("if (!focused) {"),
+                "effectiveUnreadCount must fall back to the title when unfocused"
+            );
+        }
+
+        /// The reconciliation latch must survive the window losing focus (so the
+        /// badge does not re-raise from the still-stale title) yet yield to a
+        /// genuinely new message that bumps the title past the latched value.
+        #[test]
+        fn latch_survives_unfocus_but_yields_to_new_message() {
+            assert!(
+                UNREAD_OBSERVER_SCRIPT.contains("reconciledTitleCount === titleCount"),
+                "effectiveUnreadCount must honour the latch while the title is unchanged"
+            );
+            assert!(
+                UNREAD_OBSERVER_SCRIPT.contains("function clearReconcileLatch"),
+                "script must define clearReconcileLatch to invalidate the latch"
+            );
+        }
+
+        /// `resetActivityState()` must NOT clear the latch while the title still
+        /// shows "(N)" — otherwise the next unfocused poll re-raises the badge
+        /// from the stale title.  The latch may only be dropped once the title
+        /// itself has returned to 0.
+        #[test]
+        fn reset_only_clears_latch_when_title_is_zero() {
+            assert!(
+                UNREAD_OBSERVER_SCRIPT
+                    .contains("if (getUnreadCountFromTitle() <= 0) {\n            clearReconcileLatch();"),
+                "resetActivityState must guard clearReconcileLatch behind a title<=0 check"
             );
         }
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -498,10 +498,33 @@ const UNREAD_OBSERVER_SCRIPT: &str = r#"
     function clearReconcileLatch() {
         reconciledTitleCount = -1;
         reconciledValue = -1;
+        _lastMultiSenderDom = -1;
     }
 
     function effectiveUnreadCount() {
         var titleCount = getUnreadCountFromTitle();
+        // Always consult the sidebar DOM.  The window title's "(N)" is the unread
+        // count of the *currently-open* conversation, NOT the total number of
+        // unread conversations — so a message from a second sender (while a first
+        // is still unread) never raises the title past "(1)".  Counting unread
+        // sidebar threads is the only reliable signal for that case.  Returns
+        // -1 when the conversation list is absent (cannot be trusted).
+        var domUnread = countUnreadThreadsFromDom();
+
+        // DOM shows MORE unread threads than the title → a second/third sender.
+        // Drive the effective count up so Rust sees count_increased and fires,
+        // regardless of focus (an unfocused new message must still notify; a
+        // focused one updates the badge).  The latch is irrelevant when rising.
+        if (domUnread > titleCount) {
+            clearReconcileLatch();
+            if (domUnread !== _lastMultiSenderDom) {
+                _lastMultiSenderDom = domUnread;
+                jlog('[MultiSender] title=' + titleCount + ' domUnread=' + domUnread
+                    + ' — using DOM count (second sender not reflected in title)');
+            }
+            return domUnread;
+        }
+
         if (titleCount <= 0) {
             clearReconcileLatch();
             return titleCount;
@@ -520,7 +543,6 @@ const UNREAD_OBSERVER_SCRIPT: &str = r#"
             // (DOM may not have rendered its unread marker yet) still notifies.
             return titleCount;
         }
-        var domUnread = countUnreadThreadsFromDom();
         if (domUnread < 0) {
             return titleCount; // conversation list absent — cannot trust DOM
         }
@@ -673,6 +695,15 @@ const UNREAD_OBSERVER_SCRIPT: &str = r#"
     // Returns -1 ("unknown") when the conversation list is not present in the DOM
     // (e.g. a narrow/thread-only view) so callers never clear a badge based on an
     // absent list.  Otherwise returns the number of unread thread links.
+    //
+    // PERFORMANCE NOTE: this walks every sidebar thread link and calls
+    // getComputedStyle per span — it forces layout.  Called every 2 s via the
+    // poll when effectiveUnreadCount is invoked.  The early return above
+    // (links.length === 0) keeps the idle cost near-zero when the list is not in
+    // the DOM; when the list is present the cost is proportional to the number
+    // of visible conversations (~20–30 on a typical screen).  If jank is observed
+    // on low-end hardware, consider reducing the poll frequency or adding an
+    // RAF-gated debounce before the scan.
     // ---------------------------------------------------------------------------
     function countUnreadThreadsFromDom() {
         try {
@@ -1009,6 +1040,7 @@ const UNREAD_OBSERVER_SCRIPT: &str = r#"
     var zeroTimer = null;
     var lastRisingEdgeBucket = 0;   // set on 0→positive transition — logged only, not in sig
     var prevTitleCount = 0;         // track previous count for rising-edge logging
+    var _lastMultiSenderDom = -1;   // throttle [MultiSender] log to only fire when domUnread changes
 
     function coarseBucket() {
         return Math.floor(Date.now() / 2000);
@@ -1093,7 +1125,11 @@ const UNREAD_OBSERVER_SCRIPT: &str = r#"
     }
 
     function refreshActivitySnapshot() {
-        var currentCount = getUnreadCountFromTitle();
+        // Use the EFFECTIVE count (title OR sidebar DOM), not the raw title.
+        // The title's "(N)" only reflects the open conversation, so a second
+        // unread sender leaves it at "(1)"/absent and the snapshot would never
+        // refresh — leaving activity_sig empty and the new sender undetected.
+        var currentCount = effectiveUnreadCount();
         if (currentCount === 0) return;
         var snap = getActivitySnapshot(currentCount);
         if (snap.length === 0) return;
@@ -6912,6 +6948,51 @@ mod tests {
                 UNREAD_OBSERVER_SCRIPT
                     .contains("if (getUnreadCountFromTitle() <= 0) {\n            clearReconcileLatch();"),
                 "resetActivityState must guard clearReconcileLatch behind a title<=0 check"
+            );
+        }
+
+        /// A second sender does not raise the window title past "(1)" (the title
+        /// reflects the OPEN conversation only).  effectiveUnreadCount must use
+        /// the higher DOM unread-thread count when the DOM shows more unread
+        /// threads than the title, so Rust sees count_increased and fires.
+        #[test]
+        fn second_sender_uses_higher_dom_count() {
+            assert!(
+                UNREAD_OBSERVER_SCRIPT.contains("if (domUnread > titleCount) {"),
+                "effectiveUnreadCount must raise the count when the DOM shows more unread threads than the title"
+            );
+            assert!(
+                UNREAD_OBSERVER_SCRIPT.contains("[MultiSender]"),
+                "the multi-sender DOM-over-title path must be diagnostically logged"
+            );
+        }
+
+        /// The [MultiSender] diagnostic must be throttled so the 2 s poll does
+        /// not log the same domUnread value repeatedly — otherwise the log file
+        /// grows with identical lines every poll cycle.
+        #[test]
+        fn multisender_log_is_throttled() {
+            assert!(
+                UNREAD_OBSERVER_SCRIPT.contains("if (domUnread !== _lastMultiSenderDom)"),
+                "MultiSender diagnostic must only fire when domUnread changes"
+            );
+            assert!(
+                UNREAD_OBSERVER_SCRIPT.contains("_lastMultiSenderDom = -1"),
+                "clearReconcileLatch must reset the MultiSender throttle so it can re-fire"
+            );
+        }
+
+        /// The activity snapshot (which feeds activity_sig) must be refreshed
+        /// against the EFFECTIVE count, not the raw title — otherwise a second
+        /// sender (title still "(1)"/absent) never builds a signature and the
+        /// sig-change notification path stays permanently inactive.
+        #[test]
+        fn snapshot_refresh_uses_effective_count() {
+            assert!(
+                UNREAD_OBSERVER_SCRIPT.contains(
+                    "function refreshActivitySnapshot() {\n        // Use the EFFECTIVE count"
+                ),
+                "refreshActivitySnapshot must derive its count from effectiveUnreadCount"
             );
         }
     }


### PR DESCRIPTION
Follow-up to #40 addressing four runtime issues reported on the merged `1.5.4-main` testing build, plus re-audit gaps.

## 1. Time-based re-arm disabled (temporary)
Even with the cap-to-one-fire fix from #40, the 60-second reminder notification is undesirable in practice. Both `time_rearm` computations are now gated behind a new `TIME_REARM_ENABLED = false` master switch. The full `time_rearm` logic **and its 7 regression tests are preserved** (tests early-return when disabled), so the feature can be re-enabled by flipping a single `const`.

## 2. Dock badge stuck at `[1]` after reading a conversation in-place
Messenger keeps the `(N)` prefix in `document.title` until the user navigates, so the badge never cleared on an in-place read (only on a conversation switch).

- Added `countUnreadThreadsFromDom()` — counts unread thread links in the sidebar DOM (returns `-1`/unknown when the list is absent).
- Added `effectiveUnreadCount()` with a **focus-gated reconciliation latch**: when the window is focused and the DOM shows fewer unread threads than the title, the lower DOM value drives the badge.
- The latch **survives unfocus** (so the badge doesn't re-raise from the stale title) but **yields to a genuinely new message** that bumps the title past the latched value — so new-message notifications are never suppressed.
- `resetActivityState()` only drops the latch once the title itself returns to 0 (prevents a re-raise-on-unfocus regression).
- Wired into observer init, the title observer, the 2s poll, the focus handler, and the delayed-send re-read.

## 3. macOS App Translocation guard
**Root cause of "no logs / no notifications" on the downloaded testing build.** An ad-hoc-signed, un-notarized `.app` carries `com.apple.quarantine` when downloaded, so Gatekeeper runs it **translocated** from an ephemeral read-only `/AppTranslocation/<UUID>/` mount where the log file is never written and native notifications don't deliver — the app appears broken for no visible reason.

- Added pure, unit-tested `is_translocated_path()`.
- On macOS startup: if `current_exe()` is translocated, log a warning and show a dialog telling the tester to run `xattr -dr com.apple.quarantine "/Applications/Messenger X.app"`.
- No-op on Linux/Windows and for properly installed builds. The real cure is Developer ID signing + notarization (FEAT-003, externally blocked).

## 4. Second-sender unread not detected (no badge / no notification)
**Root cause (proven from the production log + a live repro):** the window title `(N)` is the unread count of the **currently-open conversation only**, so a message from a second sender while a first is still unread never raises it past `(1)`. `count_increased` therefore never fired, and `activity_sig` stayed permanently empty because `refreshActivitySnapshot()` was gated on the (wrong) title count — so the sig-change path was inactive too. The 2s poll logged `same-activity-suppressed` repeatedly (the "repetitive checks").

- `effectiveUnreadCount()` now returns `max(titleCount, countUnreadThreadsFromDom())` — when the sidebar shows more unread threads than the title, it uses the DOM count, focus-independent → Rust sees `count_increased` and fires. Logged as `[MultiSender]`, **throttled** (change-based via `_lastMultiSenderDom`) so the 2s poll does not spam identical lines.
- `refreshActivitySnapshot()` derives its count from `effectiveUnreadCount()` instead of the title, so the activity signature is built for DOM-detected unread threads even when the title shows no count.
- **Verified on a live Messenger session:** `getActivitySnapshot` reported `candidates=2 snapshot="Jan Cizek|canadafreed0m"` for two distinct unread senders (previously 0 candidates / empty sig).

## Re-audit gaps fixed (post-initial implementation)
- `resetActivityState()` unconditionally called `clearReconcileLatch()` — if the title still showed `(N)` after an in-place read, the next unfocused poll re-raised the badge from the stale title. Fixed by gating the clear behind `getUnreadCountFromTitle() <= 0`.
- `[MultiSender]` diagnostic was unthrottled — would log every 2s poll while the multi-sender state persisted. Fixed with `_lastMultiSenderDom` change-based throttle, reset in `clearReconcileLatch`.
- `countUnreadThreadsFromDom()` forces layout (getComputedStyle per span). Added a performance comment documenting the scan cost and the `links.length === 0` early-return safeguard.

## Verification
- `cargo test`: **102 lib + 12 + 2 integration** tests pass.
- `cargo clippy --all-targets`: clean.
- `npx tsc --noEmit`: clean.
