### PR TITLE
ci: fix patch registry override condition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -645,7 +645,7 @@ jobs:
       always() &&
       needs.publish-updater.result == 'success' &&
       needs.create-release.outputs.is-backbuild != 'true' &&
-      (endsWith(needs.create-release.outputs.tag-name, '.0') || inputs.update_registries == 'true')
+      (endsWith(needs.create-release.outputs.tag-name, '.0') || inputs.update_registries)
     runs-on: ubuntu-latest
 
     steps:
@@ -705,7 +705,7 @@ jobs:
       always() &&
       needs.publish-updater.result == 'success' &&
       needs.create-release.outputs.is-backbuild != 'true' &&
-      (endsWith(needs.create-release.outputs.tag-name, '.0') || inputs.update_registries == 'true')
+      (endsWith(needs.create-release.outputs.tag-name, '.0') || inputs.update_registries)
     runs-on: windows-latest
 
     steps:
@@ -788,4 +788,3 @@ jobs:
             --token $env:WINGET_PAT
 
           Write-Host "winget manifest submitted for ${VERSION}"
-

--- a/scripts/verify-release-registry-condition.mjs
+++ b/scripts/verify-release-registry-condition.mjs
@@ -1,0 +1,68 @@
+import { readFileSync } from 'node:fs';
+
+const workflowPath = '.github/workflows/release.yml';
+const workflow = readFileSync(workflowPath, 'utf8');
+
+const jobNames = ['update-homebrew', 'update-winget'];
+const failures = [];
+
+function extractJobIfBlock(jobName) {
+  const jobStart = workflow.indexOf(`  ${jobName}:`);
+  if (jobStart === -1) {
+    failures.push(`Missing ${jobName} job`);
+    return '';
+  }
+
+  const nextJobMatch = workflow
+    .slice(jobStart + `  ${jobName}:`.length)
+    .match(/\n  [A-Za-z0-9_-]+:\n/g);
+  const nextJobStart = nextJobMatch
+    ? workflow.indexOf(nextJobMatch[0], jobStart + `  ${jobName}:`.length)
+    : -1;
+  const jobBlock = workflow.slice(jobStart, nextJobStart === -1 ? workflow.length : nextJobStart);
+  const ifMatch = jobBlock.match(/\n    if: \|\n([\s\S]*?)(?=\n    [a-zA-Z_-]+:|\n\n|$)/);
+  if (!ifMatch) {
+    failures.push(`Missing multiline if condition on ${jobName}`);
+    return '';
+  }
+
+  return ifMatch[1]
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join(' ');
+}
+
+for (const jobName of jobNames) {
+  const condition = extractJobIfBlock(jobName);
+  if (!condition) continue;
+
+  if (!condition.includes("endsWith(needs.create-release.outputs.tag-name, '.0')")) {
+    failures.push(`${jobName} must auto-run for major/minor tags ending in .0`);
+  }
+
+  if (!condition.includes("needs.create-release.outputs.is-backbuild != 'true'")) {
+    failures.push(`${jobName} must skip tag_override backbuilds`);
+  }
+
+  if (!condition.includes('inputs.update_registries')) {
+    failures.push(`${jobName} must allow manual registry updates for patch releases`);
+  }
+
+  if (condition.includes("inputs.update_registries == 'true'")) {
+    failures.push(
+      `${jobName} compares boolean workflow_dispatch input update_registries to string 'true'; ` +
+        'use boolean truthiness so checked patch-release override enables registry jobs',
+    );
+  }
+}
+
+if (failures.length > 0) {
+  console.error('release.yml registry condition check failed:');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log('release.yml registry conditions allow .0 auto-updates and boolean patch override.');


### PR DESCRIPTION
## Summary
- Treat workflow_dispatch update_registries as a boolean in Homebrew/winget job conditions.
- Preserve automatic registry updates for .0 major/minor releases and backbuild skips.
- Add a Node regression guard for the registry job conditions.

## Test Plan
- [x] node scripts/verify-release-registry-condition.mjs
- [x] ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); YAML.load_file(".github/workflows/test-build.yml"); puts "workflow YAML parsed"'
- [x] npx tsc --noEmit
- [x] cargo clippy --all-targets --all-features -- -D warnings (from src-tauri/)
- [x] cargo test (from src-tauri/)