### PR TITLE
ci: route release bumps through PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,10 @@ on:
 # ─────────────────────────────────────────────────────────────────────────────
 # Seven-phase release:
 #
-#   0. bump-version    — (workflow_dispatch only) bump semver in source files,
-#                        commit to main, push tag; no-op on tag-push trigger
+#   0. bump-version    — (workflow_dispatch only) opens a version bump PR when
+#                        source is stale, releases already-merged version bumps,
+#                        or uses tag_override for an existing tag; no-op on
+#                        tag-push trigger
 #   1. create-release  — create a single GitHub Release (eliminates race)
 #   2. build-tauri     — 6 parallel matrix jobs upload artifacts to that release
 #   3. publish-updater — generate one complete latest.json after all builds
@@ -41,6 +43,8 @@ on:
 #
 # Triggering a release:
 #   • From GitHub UI / gh cli: Actions → Release → Run workflow → pick bump type
+#     to open a version-bump PR when needed; after merge, run it again to tag
+#     and release the already-versioned main commit
 #   • From terminal (minor/major only): git tag vX.Y.0 && git push origin vX.Y.0
 #   • Patch releases: use workflow_dispatch (patch tag push does NOT trigger CI)
 # ─────────────────────────────────────────────────────────────────────────────
@@ -48,21 +52,25 @@ on:
 jobs:
 
   # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  # Phase 0: Bump semver, commit, push tag.
-  # Only runs on workflow_dispatch. On tag-push this job is a no-op (the
-  # bump step is skipped) so downstream jobs always have a job to depend on.
+  # Phase 0: Bump semver through a PR, or tag an already-versioned main commit.
+  # Only runs on workflow_dispatch without tag_override. On tag-push this job is
+  # a no-op so downstream jobs always have a job to depend on. With tag_override,
+  # it exposes the existing tag as a backbuild.
   # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   bump-version:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     outputs:
-      new-tag:      ${{ steps.bump.outputs.new-tag || steps.override.outputs.new-tag }}
+      new-tag:      ${{ steps.bump.outputs.release-tag || steps.override.outputs.new-tag }}
       is-backbuild: ${{ steps.override.outputs.is-backbuild }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
 
       - name: Use tag_override (no bump)
         id: override
@@ -73,20 +81,32 @@ jobs:
           echo "new-tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "is-backbuild=true" >> "$GITHUB_OUTPUT"
 
-      - name: Bump version, commit and push tag
+      - name: Prepare release or open release PR
         id: bump
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.tag_override == ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
-          # Ensure we are on the latest main before reading the current version.
-          # Without this, a commit pushed between the workflow trigger and this
-          # step causes "Updates were rejected (fetch first)" on git push.
-          git fetch origin main
+          # Ensure we are on the latest main and have tags before choosing the
+          # bump base. Source files can lag behind release tags because build
+          # jobs sync versions from tags without committing back to main.
+          git fetch origin main --tags
           git rebase origin/main
 
           BUMP="${{ github.event.inputs.bump_type }}"
-          CURRENT=$(jq -r .version package.json)
+
+          BASE_TAG=$(git tag --merged origin/main --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname | sed -n '1p' || true)
+          if [[ -n "${BASE_TAG}" ]]; then
+            CURRENT="${BASE_TAG#v}"
+            echo "Using latest merged semver tag as bump base: ${BASE_TAG}"
+          else
+            FALLBACK_VERSION=$(jq -r .version package.json)
+            CURRENT="${FALLBACK_VERSION}"
+            echo "No merged semver tag found; using package.json version as bump base: ${FALLBACK_VERSION}"
+          fi
+
           IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
 
           case "$BUMP" in
@@ -97,8 +117,36 @@ jobs:
 
           NEW="${MAJOR}.${MINOR}.${PATCH}"
           TAG="v${NEW}"
+          BRANCH="release/${TAG}"
+          SOURCE_VERSION=$(jq -r .version package.json)
+          TAURI_VERSION=$(jq -r .version src-tauri/tauri.conf.json)
+          CARGO_VERSION=$(grep -m 1 '^version = ' src-tauri/Cargo.toml | cut -d'"' -f2)
 
           echo "Bumping ${CURRENT} → ${NEW} (${BUMP})"
+
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "::error::Tag ${TAG} already exists. Refusing to create duplicate release bump PR."
+            exit 1
+          fi
+
+          if [[ "${SOURCE_VERSION}" == "${NEW}" && "${TAURI_VERSION}" == "${NEW}" && "${CARGO_VERSION}" == "${NEW}" ]]; then
+            echo "Source files already carry ${NEW}; tagging current main for release."
+            git tag "${TAG}"
+            git push origin "${TAG}"
+            echo "release-tag=${TAG}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          OPEN_PR_COUNT=$(gh pr list \
+            --repo "${GITHUB_REPOSITORY}" \
+            --head "${BRANCH}" \
+            --state open \
+            --json number \
+            --jq 'length')
+          if [[ "${OPEN_PR_COUNT}" != "0" ]]; then
+            echo "::notice::Release bump PR for ${TAG} already exists: ${BRANCH}"
+            exit 0
+          fi
 
           # ── Update version in all three version-carrying files ──────────────
           jq --arg v "$NEW" '.version = $v' package.json \
@@ -117,18 +165,29 @@ jobs:
             git add src-tauri/Cargo.lock
           fi
 
-          # ── Commit and tag ────────────────────────────────────────────────────
+          # ── Commit on release branch and open PR ──────────────────────────────
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          git switch -c "${BRANCH}"
+
           git add package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml
           git commit -m "chore: bump version to ${TAG}"
-          git tag "$TAG"
 
-          git push origin HEAD:main
-          git push origin "$TAG"
+          git push origin "${BRANCH}"
 
-          echo "new-tag=${TAG}" >> "$GITHUB_OUTPUT"
+          if gh pr view "${BRANCH}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "Release bump PR for ${TAG} already exists: ${BRANCH}"
+          else
+            gh pr create \
+              --repo "${GITHUB_REPOSITORY}" \
+              --base main \
+              --head "${BRANCH}" \
+              --title "chore: bump version to ${TAG}" \
+              --body "Automated version bump for ${TAG}. Merge this PR, then run the Release workflow again with bump_type=${BUMP} to tag and release the already-versioned main commit. For patch releases that should update Homebrew/winget, check update_registries on that second run."
+          fi
+
+          echo "::notice::Opened release bump PR for ${TAG}. Merge it, then rerun this workflow with bump_type=${BUMP} to tag and release."
 
   # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   # Phase 1: Create a single GitHub Release before any builds start.
@@ -139,7 +198,7 @@ jobs:
     if: |
       always() &&
       needs.bump-version.result != 'failure' &&
-      (startsWith(github.ref, 'refs/tags/v') || needs.bump-version.outputs.new-tag != '')
+      (startsWith(github.ref, 'refs/tags/v') || needs.bump-version.outputs.new-tag != '' || needs.bump-version.outputs.is-backbuild == 'true')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/scripts/verify-release-bump-pr-flow.mjs
+++ b/scripts/verify-release-bump-pr-flow.mjs
@@ -1,0 +1,162 @@
+import { readFileSync } from 'node:fs';
+
+const workflowPath = '.github/workflows/release.yml';
+const workflow = readFileSync(workflowPath, 'utf8');
+const failures = [];
+
+function extractStepBlock(stepName) {
+  const stepStart = workflow.indexOf(`      - name: ${stepName}`);
+  if (stepStart === -1) {
+    failures.push(`Missing workflow step: ${stepName}`);
+    return '';
+  }
+
+  const nextStepStart = workflow.indexOf('\n      - name:', stepStart + `      - name: ${stepName}`.length);
+  return workflow.slice(stepStart, nextStepStart === -1 ? workflow.length : nextStepStart);
+}
+
+function latestSemverTag(tags) {
+  const parsed = tags
+    .map((tag) => {
+      const match = /^v(\d+)\.(\d+)\.(\d+)$/.exec(tag);
+      if (!match) return null;
+      return {
+        tag,
+        major: Number(match[1]),
+        minor: Number(match[2]),
+        patch: Number(match[3]),
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) =>
+      b.major - a.major || b.minor - a.minor || b.patch - a.patch,
+    );
+
+  return parsed[0]?.tag ?? '';
+}
+
+function bumpVersion(current, bumpType) {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(current);
+  if (!match) {
+    throw new Error(`Invalid semver: ${current}`);
+  }
+
+  let major = Number(match[1]);
+  let minor = Number(match[2]);
+  let patch = Number(match[3]);
+
+  switch (bumpType) {
+    case 'major':
+      major += 1;
+      minor = 0;
+      patch = 0;
+      break;
+    case 'minor':
+      minor += 1;
+      patch = 0;
+      break;
+    case 'patch':
+      patch += 1;
+      break;
+    default:
+      throw new Error(`Invalid bump type: ${bumpType}`);
+  }
+
+  return `${major}.${minor}.${patch}`;
+}
+
+const latestTag = latestSemverTag(['v1.5.6', 'v1.5.5', 'v1.5.4', 'not-a-version']);
+if (latestTag !== 'v1.5.6') {
+  failures.push(`latestSemverTag should choose v1.5.6, got ${latestTag || '<empty>'}`);
+}
+
+const nextPatch = bumpVersion(latestTag.replace(/^v/, ''), 'patch');
+if (nextPatch !== '1.5.7') {
+  failures.push(`patch bump from latest tag v1.5.6 should be 1.5.7, got ${nextPatch}`);
+}
+
+const bumpJobStart = workflow.indexOf('  bump-version:');
+const createReleaseStart = workflow.indexOf('\n  create-release:', bumpJobStart);
+const bumpJob = workflow.slice(bumpJobStart, createReleaseStart === -1 ? workflow.length : createReleaseStart);
+const bumpStep = extractStepBlock('Prepare release or open release PR');
+
+const requiredSnippets = [
+  {
+    text: 'git tag --merged origin/main',
+    message: 'bump-version must discover latest semver tag merged into origin/main',
+  },
+  {
+    text: 'fetch-depth: 0',
+    message: 'bump-version checkout must fetch full history so merged-tag detection is reliable',
+  },
+  {
+    text: 'CURRENT="${BASE_TAG#v}"',
+    message: 'bump-version must use latest tag as CURRENT when a semver tag exists',
+  },
+  {
+    text: 'BRANCH="release/${TAG}"',
+    message: 'bump-version must create a dedicated release branch',
+  },
+  {
+    text: 'gh pr create',
+    message: 'bump-version must open a PR instead of pushing directly to main',
+  },
+  {
+    text: 'git push origin "${BRANCH}"',
+    message: 'bump-version must push the release branch',
+  },
+  {
+    text: 'SOURCE_VERSION=$(jq -r .version package.json)',
+    message: 'bump-version must detect already-versioned main before opening a PR',
+  },
+  {
+    text: 'git push origin "${TAG}"',
+    message: 'bump-version must tag an already-versioned main commit after the bump PR is merged',
+  },
+  {
+    text: 'echo "release-tag=${TAG}" >> "$GITHUB_OUTPUT"',
+    message: 'bump-version must only release when it emits release-tag output',
+  },
+];
+
+for (const snippet of requiredSnippets) {
+  const haystack = snippet.text === 'fetch-depth: 0' ? bumpJob : bumpStep;
+  if (!haystack.includes(snippet.text)) {
+    failures.push(snippet.message);
+  }
+}
+
+const forbiddenSnippets = [
+  {
+    text: 'git push origin HEAD:main',
+    message: 'bump-version must not push directly to protected main',
+  },
+  {
+    text: 'git tag "$TAG"',
+    message: 'bump-version must use braced tag variable inside the already-versioned guard',
+  },
+  {
+    text: 'CURRENT=$(jq -r .version package.json)',
+    message: 'bump-version must not use stale package.json as the primary bump base',
+  },
+  {
+    text: 'new-tag=${TAG}',
+    message: 'bump-version must not emit new-tag after opening a bump PR',
+  },
+];
+
+for (const snippet of forbiddenSnippets) {
+  if (bumpStep.includes(snippet.text)) {
+    failures.push(snippet.message);
+  }
+}
+
+if (failures.length > 0) {
+  console.error('release.yml bump PR flow check failed:');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log('release.yml bump flow uses latest semver tag and creates a release PR.');

--- a/scripts/verify-release-registry-condition.mjs
+++ b/scripts/verify-release-registry-condition.mjs
@@ -6,6 +6,10 @@ const workflow = readFileSync(workflowPath, 'utf8');
 const jobNames = ['update-homebrew', 'update-winget'];
 const failures = [];
 
+function normalizeCondition(condition) {
+  return condition.replace(/\s+/g, ' ').trim();
+}
+
 function extractJobIfBlock(jobName) {
   const jobStart = workflow.indexOf(`  ${jobName}:`);
   if (jobStart === -1) {
@@ -33,8 +37,16 @@ function extractJobIfBlock(jobName) {
     .join(' ');
 }
 
+function registryJobShouldRun({ tagName, updateRegistries, isBackbuild, publishUpdaterSucceeded }) {
+  return (
+    publishUpdaterSucceeded &&
+    !isBackbuild &&
+    (tagName.endsWith('.0') || updateRegistries === true)
+  );
+}
+
 for (const jobName of jobNames) {
-  const condition = extractJobIfBlock(jobName);
+  const condition = normalizeCondition(extractJobIfBlock(jobName));
   if (!condition) continue;
 
   if (!condition.includes("endsWith(needs.create-release.outputs.tag-name, '.0')")) {
@@ -53,6 +65,38 @@ for (const jobName of jobNames) {
     failures.push(
       `${jobName} compares boolean workflow_dispatch input update_registries to string 'true'; ` +
         'use boolean truthiness so checked patch-release override enables registry jobs',
+    );
+  }
+}
+
+const scenarios = [
+  {
+    name: 'minor .0 release auto-runs registry updates without manual override',
+    input: { tagName: 'v1.6.0', updateRegistries: false, isBackbuild: false, publishUpdaterSucceeded: true },
+    expected: true,
+  },
+  {
+    name: 'patch release skips registry updates by default',
+    input: { tagName: 'v1.5.7', updateRegistries: false, isBackbuild: false, publishUpdaterSucceeded: true },
+    expected: false,
+  },
+  {
+    name: 'patch release runs registry updates when checkbox is checked',
+    input: { tagName: 'v1.5.7', updateRegistries: true, isBackbuild: false, publishUpdaterSucceeded: true },
+    expected: true,
+  },
+  {
+    name: 'backbuild skips registry updates even when checkbox is checked',
+    input: { tagName: 'v1.5.7', updateRegistries: true, isBackbuild: true, publishUpdaterSucceeded: true },
+    expected: false,
+  },
+];
+
+for (const scenario of scenarios) {
+  const actual = registryJobShouldRun(scenario.input);
+  if (actual !== scenario.expected) {
+    failures.push(
+      `${scenario.name}: expected ${scenario.expected ? 'run' : 'skip'}, got ${actual ? 'run' : 'skip'}`,
     );
   }
 }


### PR DESCRIPTION
## Summary
- Replace direct protected-main release bump pushes with a PR-first release bump flow.
- Use the latest semver tag merged into main as the normal workflow_dispatch bump base instead of stale package.json.
- Preserve tag_override/tag-push releases and add explicit regression guards for patch registry checkbox behavior.

## Release flow after this change
1. Run Release with bump_type=patch/minor/major. If source files are stale, it opens release/vX.Y.Z as a PR and stops before creating a release.
2. Merge the version bump PR.
3. Run Release again with the same bump_type. It detects the already-versioned main commit, tags it, and continues the release jobs.
4. For patch releases that should update Homebrew/winget, check update_registries on the second run.

## Test Plan
- [x] node scripts/verify-release-bump-pr-flow.mjs
- [x] node scripts/verify-release-registry-condition.mjs
- [x] ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); YAML.load_file(".github/workflows/test-build.yml"); puts "workflow YAML parsed"'
- [x] npx tsc --noEmit
- [x] cargo clippy --all-targets --all-features -- -D warnings (from src-tauri/)
- [x] cargo test (from src-tauri/)