### PR TITLE
ci: add tag override registry force

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,11 @@ on:
         required: false
         type: boolean
         default: false
+      force_tag_override_registry_update:
+        description: 'DANGEROUS: also submit winget + Homebrew updates for tag_override/backbuild runs (can republish or downgrade registries)'
+        required: false
+        type: boolean
+        default: false
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -644,8 +649,8 @@ jobs:
     if: |
       always() &&
       needs.publish-updater.result == 'success' &&
-      needs.create-release.outputs.is-backbuild != 'true' &&
-      (endsWith(needs.create-release.outputs.tag-name, '.0') || inputs.update_registries)
+      (needs.create-release.outputs.is-backbuild != 'true' || inputs.force_tag_override_registry_update) &&
+      (endsWith(needs.create-release.outputs.tag-name, '.0') || inputs.update_registries || inputs.force_tag_override_registry_update)
     runs-on: ubuntu-latest
 
     steps:
@@ -705,8 +710,8 @@ jobs:
     if: |
       always() &&
       needs.publish-updater.result == 'success' &&
-      needs.create-release.outputs.is-backbuild != 'true' &&
-      (endsWith(needs.create-release.outputs.tag-name, '.0') || inputs.update_registries)
+      (needs.create-release.outputs.is-backbuild != 'true' || inputs.force_tag_override_registry_update) &&
+      (endsWith(needs.create-release.outputs.tag-name, '.0') || inputs.update_registries || inputs.force_tag_override_registry_update)
     runs-on: windows-latest
 
     steps:

--- a/scripts/verify-release-registry-condition.mjs
+++ b/scripts/verify-release-registry-condition.mjs
@@ -6,6 +6,10 @@ const workflow = readFileSync(workflowPath, 'utf8');
 const jobNames = ['update-homebrew', 'update-winget'];
 const failures = [];
 
+function normalizeCondition(condition) {
+  return condition.replace(/\s+/g, ' ').trim();
+}
+
 function extractJobIfBlock(jobName) {
   const jobStart = workflow.indexOf(`  ${jobName}:`);
   if (jobStart === -1) {
@@ -33,26 +37,79 @@ function extractJobIfBlock(jobName) {
     .join(' ');
 }
 
+function registryJobShouldRun({ tagName, updateRegistries, forceTagOverrideRegistryUpdate, isBackbuild, publishUpdaterSucceeded }) {
+  return (
+    publishUpdaterSucceeded &&
+    (!isBackbuild || forceTagOverrideRegistryUpdate === true) &&
+    (tagName.endsWith('.0') || updateRegistries === true || forceTagOverrideRegistryUpdate === true)
+  );
+}
+
+if (!workflow.includes('force_tag_override_registry_update:')) {
+  failures.push('workflow_dispatch must expose force_tag_override_registry_update checkbox for explicit tag_override registry updates');
+}
+
 for (const jobName of jobNames) {
-  const condition = extractJobIfBlock(jobName);
+  const condition = normalizeCondition(extractJobIfBlock(jobName));
   if (!condition) continue;
 
   if (!condition.includes("endsWith(needs.create-release.outputs.tag-name, '.0')")) {
     failures.push(`${jobName} must auto-run for major/minor tags ending in .0`);
   }
 
-  if (!condition.includes("needs.create-release.outputs.is-backbuild != 'true'")) {
-    failures.push(`${jobName} must skip tag_override backbuilds`);
+  if (!condition.includes("needs.create-release.outputs.is-backbuild != 'true'") || !condition.includes('inputs.force_tag_override_registry_update')) {
+    failures.push(`${jobName} must skip tag_override backbuilds unless force_tag_override_registry_update is checked`);
   }
 
   if (!condition.includes('inputs.update_registries')) {
     failures.push(`${jobName} must allow manual registry updates for patch releases`);
   }
 
+  if (!condition.includes('inputs.force_tag_override_registry_update')) {
+    failures.push(`${jobName} must allow explicit registry updates for tag_override runs`);
+  }
+
   if (condition.includes("inputs.update_registries == 'true'")) {
     failures.push(
       `${jobName} compares boolean workflow_dispatch input update_registries to string 'true'; ` +
         'use boolean truthiness so checked patch-release override enables registry jobs',
+    );
+  }
+}
+
+const scenarios = [
+  {
+    name: 'minor .0 release auto-runs registry updates without manual override',
+    input: { tagName: 'v1.6.0', updateRegistries: false, forceTagOverrideRegistryUpdate: false, isBackbuild: false, publishUpdaterSucceeded: true },
+    expected: true,
+  },
+  {
+    name: 'patch release skips registry updates by default',
+    input: { tagName: 'v1.5.7', updateRegistries: false, forceTagOverrideRegistryUpdate: false, isBackbuild: false, publishUpdaterSucceeded: true },
+    expected: false,
+  },
+  {
+    name: 'patch release runs registry updates when update_registries is checked',
+    input: { tagName: 'v1.5.7', updateRegistries: true, forceTagOverrideRegistryUpdate: false, isBackbuild: false, publishUpdaterSucceeded: true },
+    expected: true,
+  },
+  {
+    name: 'tag_override backbuild skips registry updates even when update_registries is checked',
+    input: { tagName: 'v1.5.6', updateRegistries: true, forceTagOverrideRegistryUpdate: false, isBackbuild: true, publishUpdaterSucceeded: true },
+    expected: false,
+  },
+  {
+    name: 'tag_override backbuild runs registry updates when force checkbox is checked',
+    input: { tagName: 'v1.5.6', updateRegistries: false, forceTagOverrideRegistryUpdate: true, isBackbuild: true, publishUpdaterSucceeded: true },
+    expected: true,
+  },
+];
+
+for (const scenario of scenarios) {
+  const actual = registryJobShouldRun(scenario.input);
+  if (actual !== scenario.expected) {
+    failures.push(
+      `${scenario.name}: expected ${scenario.expected ? 'run' : 'skip'}, got ${actual ? 'run' : 'skip'}`,
     );
   }
 }

--- a/scripts/verify-release-registry-condition.mjs
+++ b/scripts/verify-release-registry-condition.mjs
@@ -45,6 +45,17 @@ function registryJobShouldRun({ tagName, updateRegistries, forceTagOverrideRegis
   );
 }
 
+function conditionMatchesExpectedGuard(condition) {
+  const expected = [
+    'always() &&',
+    "needs.publish-updater.result == 'success' &&",
+    "(needs.create-release.outputs.is-backbuild != 'true' || inputs.force_tag_override_registry_update) &&",
+    "(endsWith(needs.create-release.outputs.tag-name, '.0') || inputs.update_registries || inputs.force_tag_override_registry_update)",
+  ].join(' ');
+
+  return condition === expected;
+}
+
 if (!workflow.includes('force_tag_override_registry_update:')) {
   failures.push('workflow_dispatch must expose force_tag_override_registry_update checkbox for explicit tag_override registry updates');
 }
@@ -52,6 +63,10 @@ if (!workflow.includes('force_tag_override_registry_update:')) {
 for (const jobName of jobNames) {
   const condition = normalizeCondition(extractJobIfBlock(jobName));
   if (!condition) continue;
+
+  if (!conditionMatchesExpectedGuard(condition)) {
+    failures.push(`${jobName} registry condition must exactly match the expected backbuild-force guard`);
+  }
 
   if (!condition.includes("endsWith(needs.create-release.outputs.tag-name, '.0')")) {
     failures.push(`${jobName} must auto-run for major/minor tags ending in .0`);


### PR DESCRIPTION
## Summary
- Add explicit force_tag_override_registry_update checkbox for tag_override/backbuild registry publishing.
- Preserve default safety: tag_override runs still skip Homebrew/winget unless the dangerous force checkbox is checked.
- Extend registry condition guard with normal patch, .0, tag_override skip, and tag_override force scenarios.

## Root Cause
Run 26723015837 used tag_override=v1.5.6, which sets is-backbuild=true. The existing update_registries checkbox only overrides patch-vs-.0 rules; it intentionally did not override backbuild safety.

## Test Plan
- [x] node scripts/verify-release-registry-condition.mjs
- [x] ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); YAML.load_file(".github/workflows/test-build.yml"); puts "workflow YAML parsed"'
- [x] npx tsc --noEmit
- [x] cargo clippy --all-targets --all-features -- -D warnings (from src-tauri/)
- [x] cargo test (from src-tauri/)