### PR TITLE
ci: fix winget manifest submit path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -831,10 +831,12 @@ jobs:
             --token $env:WINGET_PAT `
             --out $manifestDir
 
+          $generatedManifestDir = Join-Path $manifestDir "manifests\j\jimicze\MessengerX\$VERSION"
+
           # Fix typo in repo name that was carried over from the initial v1.3.1 manifest.
           # Old (typo): fb-messanger-crossplatform
           # Correct:    fb-messenger-crossplatform
-          $localePath = "$manifestDir\j\jimicze\MessengerX\$VERSION\jimicze.MessengerX.locale.en-US.yaml"
+          $localePath = Join-Path $generatedManifestDir "jimicze.MessengerX.locale.en-US.yaml"
           if (Test-Path $localePath) {
             $content = Get-Content $localePath -Raw
             $fixed   = $content -replace 'fb-messanger-crossplatform', 'fb-messenger-crossplatform'
@@ -849,7 +851,7 @@ jobs:
           }
 
           # Submit the patched manifest as a PR to microsoft/winget-pkgs
-          .\wingetcreate.exe submit "$manifestDir\j\jimicze\MessengerX\$VERSION" `
+          .\wingetcreate.exe submit $generatedManifestDir `
             --token $env:WINGET_PAT
 
           Write-Host "winget manifest submitted for ${VERSION}"

--- a/scripts/verify-release-winget-path.mjs
+++ b/scripts/verify-release-winget-path.mjs
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs';
+
+const workflow = readFileSync('.github/workflows/release.yml', 'utf8');
+const failures = [];
+
+const requiredSnippets = [
+  {
+    text: '$generatedManifestDir = Join-Path $manifestDir "manifests\\j\\jimicze\\MessengerX\\$VERSION"',
+    message: 'winget workflow must use wingetcreate output path under winget-manifests\\manifests',
+  },
+  {
+    text: '$localePath = Join-Path $generatedManifestDir "jimicze.MessengerX.locale.en-US.yaml"',
+    message: 'locale manifest path must be derived from generatedManifestDir',
+  },
+  {
+    text: '.\\wingetcreate.exe submit $generatedManifestDir',
+    message: 'winget submit must use the generated manifest directory',
+  },
+];
+
+const forbiddenSnippets = [
+  {
+    text: '$manifestDir\j\jimicze\MessengerX\$VERSION',
+    message: 'winget workflow must not use the pre-wingetcreate path missing the manifests segment',
+  },
+  {
+    text: '.\\wingetcreate.exe submit "$manifestDir\j\jimicze\MessengerX\$VERSION"',
+    message: 'winget submit must not use a path missing the manifests segment',
+  },
+];
+
+for (const snippet of requiredSnippets) {
+  if (!workflow.includes(snippet.text)) {
+    failures.push(snippet.message);
+  }
+}
+
+for (const snippet of forbiddenSnippets) {
+  if (workflow.includes(snippet.text)) {
+    failures.push(snippet.message);
+  }
+}
+
+if (failures.length > 0) {
+  console.error('release.yml winget manifest path check failed:');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log('release.yml winget path uses wingetcreate generated manifests directory.');


### PR DESCRIPTION
## Summary
- Use the actual wingetcreate output directory under winget-manifests/manifests for locale patching and submit.
- Add a workflow verifier that catches the old path missing the manifests segment.

## Root Cause
Run 26725036456 showed wingetcreate wrote manifests to winget-manifests/manifests/j/jimicze/MessengerX/1.5.7, while the workflow looked under winget-manifests/j/jimicze/MessengerX/1.5.7 and then submitted a non-existent path.

## Test Plan
- [x] node scripts/verify-release-winget-path.mjs
- [x] node scripts/verify-release-registry-condition.mjs
- [x] node scripts/verify-release-bump-pr-flow.mjs
- [x] ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); YAML.load_file(".github/workflows/test-build.yml"); puts "workflow YAML parsed"'
- [x] npx tsc --noEmit
- [x] cargo clippy --all-targets --all-features -- -D warnings (from src-tauri/)
- [x] cargo test (from src-tauri/)